### PR TITLE
Add support for more fields and refactor parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
   env: {
     node: true,
   },
-  extends: [
-    'airbnb-base',
-  ],
+  extends: ['airbnb-base'],
+  rules: {
+    'no-console': ['off'],
+  },
 };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Run Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Run Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "singleQuote": true,
+    "trailingComma": "all"
+}

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const requestBuilder = require('./requestBuilder');
 const Parsers = require('./parsers');
 
 class Darwin {
-  constructor(apiKey, options) {
+  constructor(apiKey, options = {}) {
     this.key = apiKey || process.env.DARWIN_TOKEN;
     this.baseUrl = 'https://lite.realtime.nationalrail.co.uk/OpenLDBWS/ldb11.asmx';
 
@@ -19,7 +19,8 @@ class Darwin {
 
   static get(url) {
     return new Promise((resolve, reject) => {
-      axios.get(url)
+      axios
+        .get(url)
         .then((response) => {
           if (response.status > 300) {
             reject(response);
@@ -36,11 +37,12 @@ class Darwin {
   post(xml) {
     const xmlWithToken = xml.replace('$$TOKEN$$', this.key);
     return new Promise((resolve, reject) => {
-      axios.post(this.baseUrl, xmlWithToken, {
-        headers: {
-          'Content-Type': 'text/xml',
-        },
-      })
+      axios
+        .post(this.baseUrl, xmlWithToken, {
+          headers: {
+            'Content-Type': 'text/xml',
+          },
+        })
         .then((response) => {
           if (response.status > 300) {
             reject(response);
@@ -54,7 +56,7 @@ class Darwin {
     });
   }
 
-  getDepartureBoard(station, options) {
+  getDepartureBoard(station, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getDepartureBoardRequest(station, options);
       this.post(requestXML)
@@ -67,7 +69,7 @@ class Darwin {
     });
   }
 
-  getDepartureBoardWithDetails(station, options) {
+  getDepartureBoardWithDetails(station, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getDepartureBoardWithDetails(station, options);
       this.post(requestXML)
@@ -80,7 +82,7 @@ class Darwin {
     });
   }
 
-  getArrivalsBoard(station, options) {
+  getArrivalsBoard(station, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getArrivalsBoard(station, options);
       this.post(requestXML)
@@ -93,7 +95,7 @@ class Darwin {
     });
   }
 
-  getArrivalsBoardWithDetails(station, options) {
+  getArrivalsBoardWithDetails(station, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getArrivalsBoardWithDetails(station, options);
       this.post(requestXML)
@@ -106,7 +108,7 @@ class Darwin {
     });
   }
 
-  getArrivalsDepartureBoard(station, options) {
+  getArrivalsDepartureBoard(station, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getArrivalsDepartureBoard(station, options);
       this.post(requestXML)
@@ -119,7 +121,7 @@ class Darwin {
     });
   }
 
-  getArrivalsDepartureBoardWithDetails(station, options) {
+  getArrivalsDepartureBoardWithDetails(station, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getArrivalsDepartureBoardWithDetails(station, options);
       this.post(requestXML)
@@ -145,7 +147,7 @@ class Darwin {
     });
   }
 
-  getNextDeparture(station, destination, options) {
+  getNextDeparture(station, destination, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getNextDeparture(station, destination, options);
       this.post(requestXML)
@@ -158,7 +160,7 @@ class Darwin {
     });
   }
 
-  getNextDepartureWithDetails(station, destination, options) {
+  getNextDepartureWithDetails(station, destination, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getNextDepartureWithDetails(station, destination, options);
       this.post(requestXML)
@@ -171,7 +173,7 @@ class Darwin {
     });
   }
 
-  getArrival(station, destination, options) {
+  getArrival(station, destination, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getArrival(station, destination, options);
       this.post(requestXML)
@@ -184,7 +186,7 @@ class Darwin {
     });
   }
 
-  getFastestDeparture(station, destination, options) {
+  getFastestDeparture(station, destination, options = {}) {
     return new Promise((resolve, reject) => {
       const requestXML = requestBuilder.getFastestDeparture(station, destination, options);
       this.post(requestXML)
@@ -197,13 +199,16 @@ class Darwin {
     });
   }
 
-  getFastestDepartureWithDetails(station, destination, options) {
+  getFastestDepartureWithDetails(station, destination, options = {}) {
     return new Promise((resolve, reject) => {
-      const requestXML = requestBuilder
-        .getFastestDepartureWithDetails(station, destination, options);
+      const requestXML = requestBuilder.getFastestDepartureWithDetails(
+        station,
+        destination,
+        options,
+      );
       this.post(requestXML)
         .then((result) => {
-          resolve(Parsers.parseFastestDeparturesWithDetail(result));
+          resolve(Parsers.parseFastestDepartureWithDetails(result));
         })
         .catch((err) => {
           reject(err);
@@ -213,7 +218,9 @@ class Darwin {
 
   static getStationDetails(stationName) {
     return new Promise((resolve, reject) => {
-      const url = `http://ojp.nationalrail.co.uk/find/stationsDLRLU/${encodeURIComponent(stationName)}`;
+      const url = `http://ojp.nationalrail.co.uk/find/stationsDLRLU/${encodeURIComponent(
+        stationName,
+      )}`;
       this.get(url)
         .then((body) => {
           const results = JSON.parse(body);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,360 @@
       "devDependencies": {
         "eslint": "^8.32.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-plugin-import": "^2.27.5"
+        "eslint-plugin-import": "^2.27.5",
+        "vitest": "^1.0.2"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
+      "integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
+      "integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
+      "integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
+      "integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
+      "integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
+      "integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
+      "integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
+      "integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
+      "integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
+      "integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
+      "integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
+      "integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
+      "integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
+      "integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
+      "integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
+      "integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
+      "integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
+      "integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
+      "integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
+      "integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -74,6 +427,24 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -109,16 +480,273 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
+      "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
+      "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
+      "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
+      "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
+      "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
+      "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
+      "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
+      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
+      "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
+      "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
+      "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
+      "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.0.2.tgz",
+      "integrity": "sha512-mAIo/8uddSWkjQMLFcjqZP3WmkwvvN0OtlyZIu33jFnwme3vZds8m8EDMxtj+Uzni2DwtPfHNjJcTM8zTV1f4A==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "1.0.2",
+        "@vitest/utils": "1.0.2",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.0.2.tgz",
+      "integrity": "sha512-ZcHJXPT2kg/9Hc4fNkCbItlsgZSs3m4vQbxB8LCSdzpbG85bExCmSvu6K9lWpMNdoKfAr1Jn0BwS9SWUcGnbTQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "1.0.2",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.0.2.tgz",
+      "integrity": "sha512-9ClDz2/aV5TfWA4reV7XR9p+hE0e7bifhwxlURugj3Fw0YXeTFzHmKCNEHd6wOIFMfthbGGwhlq7TOJ2jDO4/g==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.0.2.tgz",
+      "integrity": "sha512-YlnHmDntp+zNV3QoTVFI5EVHV0AXpiThd7+xnDEbWnD6fw0TH/J4/+3GFPClLimR39h6nA5m0W4Bjm5Edg4A/A==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.0.2.tgz",
+      "integrity": "sha512-GPQkGHAnFAP/+seSbB9pCsj339yRrMgILoI5H2sPevTLCYgBq0VRjF8QSllmnQyvf0EontF6KUIt2t5s2SmqoQ==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -134,6 +762,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -237,6 +874,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -280,6 +926,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -302,6 +957,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -316,6 +989,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/color-convert": {
@@ -390,6 +1075,18 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -418,6 +1115,15 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -517,6 +1223,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
+      "integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.19.8",
+        "@esbuild/android-arm64": "0.19.8",
+        "@esbuild/android-x64": "0.19.8",
+        "@esbuild/darwin-arm64": "0.19.8",
+        "@esbuild/darwin-x64": "0.19.8",
+        "@esbuild/freebsd-arm64": "0.19.8",
+        "@esbuild/freebsd-x64": "0.19.8",
+        "@esbuild/linux-arm": "0.19.8",
+        "@esbuild/linux-arm64": "0.19.8",
+        "@esbuild/linux-ia32": "0.19.8",
+        "@esbuild/linux-loong64": "0.19.8",
+        "@esbuild/linux-mips64el": "0.19.8",
+        "@esbuild/linux-ppc64": "0.19.8",
+        "@esbuild/linux-riscv64": "0.19.8",
+        "@esbuild/linux-s390x": "0.19.8",
+        "@esbuild/linux-x64": "0.19.8",
+        "@esbuild/netbsd-x64": "0.19.8",
+        "@esbuild/openbsd-x64": "0.19.8",
+        "@esbuild/sunos-x64": "0.19.8",
+        "@esbuild/win32-arm64": "0.19.8",
+        "@esbuild/win32-ia32": "0.19.8",
+        "@esbuild/win32-x64": "0.19.8"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -810,6 +1553,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -931,6 +1697,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -964,6 +1744,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
@@ -976,6 +1765,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -1153,6 +1954,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
       }
     },
     "node_modules/ignore": {
@@ -1382,6 +2192,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -1495,6 +2317,12 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1506,6 +2334,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dev": true,
+      "dependencies": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/locate-path": {
@@ -1529,6 +2373,33 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1546,6 +2417,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -1569,17 +2452,74 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
+      "integrity": "sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.10.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
@@ -1655,6 +2595,21 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -1749,6 +2704,66 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1756,6 +2771,32 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proxy-from-env": {
@@ -1791,6 +2832,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -1870,6 +2917,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
+      "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.6.1",
+        "@rollup/rollup-android-arm64": "4.6.1",
+        "@rollup/rollup-darwin-arm64": "4.6.1",
+        "@rollup/rollup-darwin-x64": "4.6.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.6.1",
+        "@rollup/rollup-linux-arm64-musl": "4.6.1",
+        "@rollup/rollup-linux-x64-gnu": "4.6.1",
+        "@rollup/rollup-linux-x64-musl": "4.6.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.6.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.6.1",
+        "@rollup/rollup-win32-x64-msvc": "4.6.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -1958,6 +3033,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
+      "integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==",
+      "dev": true
+    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -2007,6 +3121,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2017,6 +3143,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+      "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/supports-color": {
@@ -2049,6 +3187,30 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
+      "integrity": "sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.1.tgz",
+      "integrity": "sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+      "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -2071,6 +3233,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -2099,6 +3270,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
+      "dev": true
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -2121,6 +3298,149 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.6.tgz",
+      "integrity": "sha512-MD3joyAEBtV7QZPl2JVVUai6zHms3YOmLR+BpMzLlX2Yzjfcc4gTgNi09d/Rua3F4EtC8zdwPU8eQYyib4vVMQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.19.3",
+        "postcss": "^8.4.32",
+        "rollup": "^4.2.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.0.2.tgz",
+      "integrity": "sha512-h7BbMJf46fLvFW/9Ygo3snkIBEHFh6fHpB4lge98H5quYrDhPFeI3S0LREz328uqPWSnii2yeJXktQ+Pmqk5BQ==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.0.2.tgz",
+      "integrity": "sha512-F3NVwwpXfRSDnJmyv+ALPwSRVt0zDkRRE18pwUHSUPXAlWQ47rY1dc99ziMW5bBHyqwK2ERjMisLNoef64qk9w==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "1.0.2",
+        "@vitest/runner": "1.0.2",
+        "@vitest/snapshot": "1.0.2",
+        "@vitest/spy": "1.0.2",
+        "@vitest/utils": "1.0.2",
+        "acorn-walk": "^8.3.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^1.3.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.1",
+        "vite": "^5.0.0",
+        "vite-node": "1.0.2",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "^1.0.0",
+        "@vitest/ui": "^1.0.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -2174,6 +3494,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -2211,6 +3547,160 @@
     }
   },
   "dependencies": {
+    "@esbuild/android-arm": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
+      "integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
+      "integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
+      "integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
+      "integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
+      "integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
+      "integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
+      "integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
+      "integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
+      "integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
+      "integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
+      "integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
+      "integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
+      "integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
+      "integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
+      "integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
+      "integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
+      "integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
+      "integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
+      "integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
+      "integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
+      "integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
+      "dev": true,
+      "optional": true
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -2251,6 +3741,21 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2277,16 +3782,176 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
+      "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
+      "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
+      "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
+      "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
+      "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
+      "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
+      "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
+      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
+      "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
+      "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
+      "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
+      "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
+      "dev": true,
+      "optional": true
+    },
+    "@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@vitest/expect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.0.2.tgz",
+      "integrity": "sha512-mAIo/8uddSWkjQMLFcjqZP3WmkwvvN0OtlyZIu33jFnwme3vZds8m8EDMxtj+Uzni2DwtPfHNjJcTM8zTV1f4A==",
+      "dev": true,
+      "requires": {
+        "@vitest/spy": "1.0.2",
+        "@vitest/utils": "1.0.2",
+        "chai": "^4.3.10"
+      }
+    },
+    "@vitest/runner": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.0.2.tgz",
+      "integrity": "sha512-ZcHJXPT2kg/9Hc4fNkCbItlsgZSs3m4vQbxB8LCSdzpbG85bExCmSvu6K9lWpMNdoKfAr1Jn0BwS9SWUcGnbTQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "1.0.2",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+          "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^1.0.0"
+          }
+        },
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+          "dev": true
+        }
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.0.2.tgz",
+      "integrity": "sha512-9ClDz2/aV5TfWA4reV7XR9p+hE0e7bifhwxlURugj3Fw0YXeTFzHmKCNEHd6wOIFMfthbGGwhlq7TOJ2jDO4/g==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      }
+    },
+    "@vitest/spy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.0.2.tgz",
+      "integrity": "sha512-YlnHmDntp+zNV3QoTVFI5EVHV0AXpiThd7+xnDEbWnD6fw0TH/J4/+3GFPClLimR39h6nA5m0W4Bjm5Edg4A/A==",
+      "dev": true,
+      "requires": {
+        "tinyspy": "^2.2.0"
+      }
+    },
+    "@vitest/utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.0.2.tgz",
+      "integrity": "sha512-GPQkGHAnFAP/+seSbB9pCsj339yRrMgILoI5H2sPevTLCYgBq0VRjF8QSllmnQyvf0EontF6KUIt2t5s2SmqoQ==",
+      "dev": true,
+      "requires": {
+        "diff-sequences": "^29.6.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      }
+    },
     "acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true
     },
     "acorn-jsx": {
@@ -2295,6 +3960,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -2366,6 +4037,12 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2403,6 +4080,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2419,6 +4102,21 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "chai": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2427,6 +4125,15 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.2"
       }
     },
     "color-convert": {
@@ -2484,6 +4191,15 @@
         "ms": "2.1.2"
       }
     },
+    "deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2504,6 +4220,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -2584,6 +4306,36 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
+      "integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.19.8",
+        "@esbuild/android-arm64": "0.19.8",
+        "@esbuild/android-x64": "0.19.8",
+        "@esbuild/darwin-arm64": "0.19.8",
+        "@esbuild/darwin-x64": "0.19.8",
+        "@esbuild/freebsd-arm64": "0.19.8",
+        "@esbuild/freebsd-x64": "0.19.8",
+        "@esbuild/linux-arm": "0.19.8",
+        "@esbuild/linux-arm64": "0.19.8",
+        "@esbuild/linux-ia32": "0.19.8",
+        "@esbuild/linux-loong64": "0.19.8",
+        "@esbuild/linux-mips64el": "0.19.8",
+        "@esbuild/linux-ppc64": "0.19.8",
+        "@esbuild/linux-riscv64": "0.19.8",
+        "@esbuild/linux-s390x": "0.19.8",
+        "@esbuild/linux-x64": "0.19.8",
+        "@esbuild/netbsd-x64": "0.19.8",
+        "@esbuild/openbsd-x64": "0.19.8",
+        "@esbuild/sunos-x64": "0.19.8",
+        "@esbuild/win32-arm64": "0.19.8",
+        "@esbuild/win32-ia32": "0.19.8",
+        "@esbuild/win32-x64": "0.19.8"
       }
     },
     "escape-string-regexp": {
@@ -2810,6 +4562,23 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2902,6 +4671,13 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2926,6 +4702,12 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
@@ -2936,6 +4718,12 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
       }
+    },
+    "get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -3053,6 +4841,12 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true
     },
     "ignore": {
       "version": "5.2.4",
@@ -3212,6 +5006,12 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true
+    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -3294,6 +5094,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3302,6 +5108,16 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dev": true,
+      "requires": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
       }
     },
     "locate-path": {
@@ -3319,6 +5135,30 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3331,6 +5171,12 @@
       "requires": {
         "mime-db": "1.52.0"
       }
+    },
+    "mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -3347,10 +5193,28 @@
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
+    "mlly": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
+      "integrity": "sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.10.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
     },
     "natural-compare": {
@@ -3358,6 +5222,23 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "requires": {
+        "path-key": "^4.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        }
+      }
     },
     "object-inspect": {
       "version": "1.12.3",
@@ -3412,6 +5293,15 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^4.0.0"
       }
     },
     "optionator": {
@@ -3479,11 +5369,70 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "pathe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
+      }
+    },
+    "postcss": {
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -3500,6 +5449,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -3549,6 +5504,27 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
+      "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.6.1",
+        "@rollup/rollup-android-arm64": "4.6.1",
+        "@rollup/rollup-darwin-arm64": "4.6.1",
+        "@rollup/rollup-darwin-x64": "4.6.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.6.1",
+        "@rollup/rollup-linux-arm64-musl": "4.6.1",
+        "@rollup/rollup-linux-x64-gnu": "4.6.1",
+        "@rollup/rollup-linux-x64-musl": "4.6.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.6.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.6.1",
+        "@rollup/rollup-win32-x64-msvc": "4.6.1",
+        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {
@@ -3608,6 +5584,36 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "std-env": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.6.0.tgz",
+      "integrity": "sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==",
+      "dev": true
+    },
     "string.prototype.trimend": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -3645,11 +5651,26 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
+    "strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strip-literal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+      "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.10.0"
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -3670,6 +5691,24 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "tinybench": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
+      "integrity": "sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==",
+      "dev": true
+    },
+    "tinypool": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.1.tgz",
+      "integrity": "sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+      "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
       "dev": true
     },
     "tsconfig-paths": {
@@ -3693,6 +5732,12 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -3709,6 +5754,12 @@
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
       }
+    },
+    "ufo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+      "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -3729,6 +5780,60 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "vite": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.6.tgz",
+      "integrity": "sha512-MD3joyAEBtV7QZPl2JVVUai6zHms3YOmLR+BpMzLlX2Yzjfcc4gTgNi09d/Rua3F4EtC8zdwPU8eQYyib4vVMQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.19.3",
+        "fsevents": "~2.3.3",
+        "postcss": "^8.4.32",
+        "rollup": "^4.2.0"
+      }
+    },
+    "vite-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.0.2.tgz",
+      "integrity": "sha512-h7BbMJf46fLvFW/9Ygo3snkIBEHFh6fHpB4lge98H5quYrDhPFeI3S0LREz328uqPWSnii2yeJXktQ+Pmqk5BQ==",
+      "dev": true,
+      "requires": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "vitest": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.0.2.tgz",
+      "integrity": "sha512-F3NVwwpXfRSDnJmyv+ALPwSRVt0zDkRRE18pwUHSUPXAlWQ47rY1dc99ziMW5bBHyqwK2ERjMisLNoef64qk9w==",
+      "dev": true,
+      "requires": {
+        "@vitest/expect": "1.0.2",
+        "@vitest/runner": "1.0.2",
+        "@vitest/snapshot": "1.0.2",
+        "@vitest/spy": "1.0.2",
+        "@vitest/utils": "1.0.2",
+        "acorn-walk": "^8.3.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^1.3.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.1",
+        "vite": "^5.0.0",
+        "vite-node": "1.0.2",
+        "why-is-node-running": "^2.2.2"
       }
     },
     "which": {
@@ -3765,6 +5870,16 @@
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "national rail's darwin soap based api with promises",
   "main": "index.js",
   "scripts": {
-    "eslint": "eslint ./*.js"
+    "eslint": "eslint ./*.js",
+    "test": "vitest"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "eslint": "^8.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.27.5"
+    "eslint-plugin-import": "^2.27.5",
+    "vitest": "^1.0.2"
   }
 }

--- a/test/fixtures/getArrivalsBoard.xml
+++ b/test/fixtures/getArrivalsBoard.xml
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetArrivalBoardResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T07:28:55.0894432+00:00</lt4:generatedAt>
+                <lt4:locationName>London Paddington</lt4:locationName>
+                <lt4:crs>PAD</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>Major disruption to / from London Paddington due to a damage to the overhead electric wires. Trains may be cancelled or severely delayed by at least 90 minutes. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/london-paddington-20231207/"&gt;Latest Travel News. &lt;/a&gt;</lt:message>
+                    <lt:message>
+    Due to heavy rain flooding the railway between Plymouth and Exeter St Davids trains may be cancelled, delayed or revised. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/totnes-20231208/"&gt;Latest Travel News&lt;/a&gt;.</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:trainServices>
+                    <lt7:service>
+                        <lt4:sta>07:09</lt4:sta>
+                        <lt4:eta>Delayed</lt4:eta>
+                        <lt4:platform>4</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires</lt4:delayReason>
+                        <lt4:serviceID>2390333PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bedwyn</lt4:locationName>
+                                <lt4:crs>BDW</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:21</lt4:sta>
+                        <lt4:eta>Delayed</lt4:eta>
+                        <lt4:platform>10</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires</lt4:delayReason>
+                        <lt4:serviceID>2390637PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Didcot Parkway</lt4:locationName>
+                                <lt4:crs>DID</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:23</lt4:sta>
+                        <lt4:eta>07:34</lt4:eta>
+                        <lt4:platform>A</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires</lt4:delayReason>
+                        <lt4:serviceID>2382044PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Heathrow Airport T5</lt4:locationName>
+                                <lt4:crs>HWV</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:24</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2390572PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Worcester Shrub Hill</lt4:locationName>
+                                <lt4:crs>WOS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:26</lt4:sta>
+                        <lt4:eta>07:36</lt4:eta>
+                        <lt4:platform>8</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires</lt4:delayReason>
+                        <lt4:serviceID>2389781PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:26</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of damage to the overhead electric wires</lt4:cancelReason>
+                        <lt4:serviceID>2381825PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Maidenhead</lt4:locationName>
+                                <lt4:crs>MAI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:29</lt4:sta>
+                        <lt4:eta>Delayed</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2381287PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Reading</lt4:locationName>
+                                <lt4:crs>RDG</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:32</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:platform>A</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2381831PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Heathrow Airport T4</lt4:locationName>
+                                <lt4:crs>HAF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:32</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2381540PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:33</lt4:sta>
+                        <lt4:eta>Delayed</lt4:eta>
+                        <lt4:platform>7</lt4:platform>
+                        <lt4:operator>Heathrow Express</lt4:operator>
+                        <lt4:operatorCode>HX</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2388641PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Heathrow Airport T5</lt4:locationName>
+                                <lt4:crs>HWV</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:35</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of damage to the overhead electric wires</lt4:cancelReason>
+                        <lt4:serviceID>2381546PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Heathrow Airport T4</lt4:locationName>
+                                <lt4:crs>HAF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:37</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2390401PADTON__</lt4:serviceID>
+                        <lt5:rsid>GW140000</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:38</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of damage to the overhead electric wires</lt4:cancelReason>
+                        <lt4:serviceID>2381837PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Reading</lt4:locationName>
+                                <lt4:crs>RDG</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:38</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2382455PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:39</lt4:sta>
+                        <lt4:eta>Delayed</lt4:eta>
+                        <lt4:platform>11</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires</lt4:delayReason>
+                        <lt4:serviceID>2390552PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Oxford</lt4:locationName>
+                                <lt4:crs>OXF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                </lt7:trainServices>
+            </GetStationBoardResult>
+        </GetArrivalBoardResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getArrivalsBoardWithDetails.xml
+++ b/test/fixtures/getArrivalsBoardWithDetails.xml
@@ -1,0 +1,1083 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetArrBoardWithDetailsResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T18:05:11.0892705+00:00</lt4:generatedAt>
+                <lt4:locationName>London Paddington</lt4:locationName>
+                <lt4:crs>PAD</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>Lines have reopened following yesterday's damage to the overhead electric wires near London Paddington. Trains may still be cancelled or delayed. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/london-paddington-20231207/"&gt;Latest Travel News. &lt;/a&gt;</lt:message>
+                    <lt:message>
+    Due to heavy rain flooding the railway earlier today between Plymouth and Exeter St Davids trains may be cancelled, delayed or revised. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/totnes-20231208/"&gt;Latest Travel News&lt;/a&gt;.</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:trainServices>
+                    <lt7:service>
+                        <lt4:sta>17:31</lt4:sta>
+                        <lt4:eta>18:03</lt4:eta>
+                        <lt4:platform>8</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by heavy rain flooding the railway</lt4:delayReason>
+                        <lt4:serviceID>2382930PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Totnes</lt4:locationName>
+                                <lt4:crs>TOT</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Penzance</lt7:locationName>
+                                    <lt7:crs>PNZ</lt7:crs>
+                                    <lt7:st>12:15</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Erth</lt7:locationName>
+                                    <lt7:crs>SER</lt7:crs>
+                                    <lt7:st>12:24</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Camborne</lt7:locationName>
+                                    <lt7:crs>CBN</lt7:crs>
+                                    <lt7:st>12:35</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Redruth</lt7:locationName>
+                                    <lt7:crs>RED</lt7:crs>
+                                    <lt7:st>12:42</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Truro</lt7:locationName>
+                                    <lt7:crs>TRU</lt7:crs>
+                                    <lt7:st>12:55</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Austell</lt7:locationName>
+                                    <lt7:crs>SAU</lt7:crs>
+                                    <lt7:st>13:11</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Par</lt7:locationName>
+                                    <lt7:crs>PAR</lt7:crs>
+                                    <lt7:st>13:19</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bodmin Parkway</lt7:locationName>
+                                    <lt7:crs>BOD</lt7:crs>
+                                    <lt7:st>13:31</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Liskeard</lt7:locationName>
+                                    <lt7:crs>LSK</lt7:crs>
+                                    <lt7:st>13:44</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Plymouth</lt7:locationName>
+                                    <lt7:crs>PLY</lt7:crs>
+                                    <lt7:st>14:15</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Totnes</lt7:locationName>
+                                    <lt7:crs>TOT</lt7:crs>
+                                    <lt7:st>14:42</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newton Abbot</lt7:locationName>
+                                    <lt7:crs>NTA</lt7:crs>
+                                    <lt7:st>14:54</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Exeter St Davids</lt7:locationName>
+                                    <lt7:crs>EXD</lt7:crs>
+                                    <lt7:st>15:15</lt7:st>
+                                    <lt7:at>15:37</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tiverton Parkway</lt7:locationName>
+                                    <lt7:crs>TVP</lt7:crs>
+                                    <lt7:st>15:29</lt7:st>
+                                    <lt7:at>15:52</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Taunton</lt7:locationName>
+                                    <lt7:crs>TAU</lt7:crs>
+                                    <lt7:st>15:42</lt7:st>
+                                    <lt7:at>16:06</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Reading</lt7:locationName>
+                                    <lt7:crs>RDG</lt7:crs>
+                                    <lt7:st>17:05</lt7:st>
+                                    <lt7:at>17:37</lt7:at>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:42</lt4:sta>
+                        <lt4:eta>18:06</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2382529PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shenfield</lt7:locationName>
+                                    <lt7:crs>SNF</lt7:crs>
+                                    <lt7:st>16:48</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Brentwood</lt7:locationName>
+                                    <lt7:crs>BRE</lt7:crs>
+                                    <lt7:st>16:52</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Harold Wood</lt7:locationName>
+                                    <lt7:crs>HRO</lt7:crs>
+                                    <lt7:st>16:56</lt7:st>
+                                    <lt7:at>16:58</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gidea Park</lt7:locationName>
+                                    <lt7:crs>GDP</lt7:crs>
+                                    <lt7:st>16:59</lt7:st>
+                                    <lt7:at>17:01</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Romford</lt7:locationName>
+                                    <lt7:crs>RMF</lt7:crs>
+                                    <lt7:st>17:02</lt7:st>
+                                    <lt7:at>17:03</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Chadwell Heath</lt7:locationName>
+                                    <lt7:crs>CTH</lt7:crs>
+                                    <lt7:st>17:05</lt7:st>
+                                    <lt7:at>17:07</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Goodmayes</lt7:locationName>
+                                    <lt7:crs>GMY</lt7:crs>
+                                    <lt7:st>17:07</lt7:st>
+                                    <lt7:at>17:09</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Seven Kings</lt7:locationName>
+                                    <lt7:crs>SVK</lt7:crs>
+                                    <lt7:st>17:09</lt7:st>
+                                    <lt7:at>17:11</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Ilford</lt7:locationName>
+                                    <lt7:crs>IFD</lt7:crs>
+                                    <lt7:st>17:13</lt7:st>
+                                    <lt7:at>17:20</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Manor Park</lt7:locationName>
+                                    <lt7:crs>MNP</lt7:crs>
+                                    <lt7:st>17:15</lt7:st>
+                                    <lt7:at>17:23</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Forest Gate</lt7:locationName>
+                                    <lt7:crs>FOG</lt7:crs>
+                                    <lt7:st>17:18</lt7:st>
+                                    <lt7:at>17:25</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Maryland</lt7:locationName>
+                                    <lt7:crs>MYL</lt7:crs>
+                                    <lt7:st>17:20</lt7:st>
+                                    <lt7:at>17:27</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stratford (London)</lt7:locationName>
+                                    <lt7:crs>SRA</lt7:crs>
+                                    <lt7:st>17:23</lt7:st>
+                                    <lt7:at>17:29</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:28</lt7:st>
+                                    <lt7:at>17:52</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:31</lt7:st>
+                                    <lt7:at>17:55</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:34</lt7:st>
+                                    <lt7:at>17:57</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:37</lt7:st>
+                                    <lt7:at>18:00</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:39</lt7:st>
+                                    <lt7:at>18:03</lt7:at>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:45</lt4:sta>
+                        <lt4:eta>18:04</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires earlier today</lt4:delayReason>
+                        <lt4:serviceID>2381344PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Reading</lt4:locationName>
+                                <lt4:crs>RDG</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Abbey Wood</lt7:locationName>
+                                    <lt7:crs>ABW</lt7:crs>
+                                    <lt7:st>17:16</lt7:st>
+                                    <lt7:at>17:19</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Woolwich (Elizabeth line)</lt7:locationName>
+                                    <lt7:crs>WWC</lt7:crs>
+                                    <lt7:st>17:19</lt7:st>
+                                    <lt7:at>17:23</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Custom House</lt7:locationName>
+                                    <lt7:crs>CUS</lt7:crs>
+                                    <lt7:st>17:23</lt7:st>
+                                    <lt7:at>17:27</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Canary Wharf (Elizabeth line)</lt7:locationName>
+                                    <lt7:crs>CWX</lt7:crs>
+                                    <lt7:st>17:27</lt7:st>
+                                    <lt7:at>17:30</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:31</lt7:st>
+                                    <lt7:at>17:51</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:34</lt7:st>
+                                    <lt7:at>17:54</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:36</lt7:st>
+                                    <lt7:at>17:56</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:39</lt7:st>
+                                    <lt7:at>17:59</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:41</lt7:st>
+                                    <lt7:at>18:01</lt7:at>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:47</lt4:sta>
+                        <lt4:eta>18:08</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2382533PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shenfield</lt7:locationName>
+                                    <lt7:crs>SNF</lt7:crs>
+                                    <lt7:st>16:53</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Brentwood</lt7:locationName>
+                                    <lt7:crs>BRE</lt7:crs>
+                                    <lt7:st>16:57</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Harold Wood</lt7:locationName>
+                                    <lt7:crs>HRO</lt7:crs>
+                                    <lt7:st>17:01</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gidea Park</lt7:locationName>
+                                    <lt7:crs>GDP</lt7:crs>
+                                    <lt7:st>17:04</lt7:st>
+                                    <lt7:at>17:06</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Romford</lt7:locationName>
+                                    <lt7:crs>RMF</lt7:crs>
+                                    <lt7:st>17:07</lt7:st>
+                                    <lt7:at>17:09</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Chadwell Heath</lt7:locationName>
+                                    <lt7:crs>CTH</lt7:crs>
+                                    <lt7:st>17:10</lt7:st>
+                                    <lt7:at>17:13</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Goodmayes</lt7:locationName>
+                                    <lt7:crs>GMY</lt7:crs>
+                                    <lt7:st>17:12</lt7:st>
+                                    <lt7:at>17:15</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Seven Kings</lt7:locationName>
+                                    <lt7:crs>SVK</lt7:crs>
+                                    <lt7:st>17:14</lt7:st>
+                                    <lt7:at>17:18</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Ilford</lt7:locationName>
+                                    <lt7:crs>IFD</lt7:crs>
+                                    <lt7:st>17:18</lt7:st>
+                                    <lt7:at>17:25</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Manor Park</lt7:locationName>
+                                    <lt7:crs>MNP</lt7:crs>
+                                    <lt7:st>17:20</lt7:st>
+                                    <lt7:at>17:29</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Forest Gate</lt7:locationName>
+                                    <lt7:crs>FOG</lt7:crs>
+                                    <lt7:st>17:23</lt7:st>
+                                    <lt7:at>17:31</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Maryland</lt7:locationName>
+                                    <lt7:crs>MYL</lt7:crs>
+                                    <lt7:st>17:25</lt7:st>
+                                    <lt7:at>17:34</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stratford (London)</lt7:locationName>
+                                    <lt7:crs>SRA</lt7:crs>
+                                    <lt7:st>17:28</lt7:st>
+                                    <lt7:at>17:36</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:33</lt7:st>
+                                    <lt7:at>17:55</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:36</lt7:st>
+                                    <lt7:at>17:58</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:39</lt7:st>
+                                    <lt7:at>18:00</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:42</lt7:st>
+                                    <lt7:at>18:03</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:44</lt7:st>
+                                    <lt7:et>18:05</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:49</lt4:sta>
+                        <lt4:eta>Delayed</lt4:eta>
+                        <lt4:platform>5</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2392248PADTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Didcot Parkway</lt4:locationName>
+                                <lt4:crs>DID</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Didcot Parkway</lt7:locationName>
+                                    <lt7:crs>DID</lt7:crs>
+                                    <lt7:st>16:38</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cholsey</lt7:locationName>
+                                    <lt7:crs>CHO</lt7:crs>
+                                    <lt7:st>16:44</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Goring &amp; Streatley</lt7:locationName>
+                                    <lt7:crs>GOR</lt7:crs>
+                                    <lt7:st>16:49</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Pangbourne</lt7:locationName>
+                                    <lt7:crs>PAN</lt7:crs>
+                                    <lt7:st>16:53</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tilehurst</lt7:locationName>
+                                    <lt7:crs>TLH</lt7:crs>
+                                    <lt7:st>16:58</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Reading</lt7:locationName>
+                                    <lt7:crs>RDG</lt7:crs>
+                                    <lt7:st>17:11</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Twyford</lt7:locationName>
+                                    <lt7:crs>TWY</lt7:crs>
+                                    <lt7:st>17:17</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Maidenhead</lt7:locationName>
+                                    <lt7:crs>MAI</lt7:crs>
+                                    <lt7:st>17:24</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Slough</lt7:locationName>
+                                    <lt7:crs>SLO</lt7:crs>
+                                    <lt7:st>17:31</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:50</lt4:sta>
+                        <lt4:eta>18:07</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by a safety inspection of the track</lt4:delayReason>
+                        <lt4:serviceID>2381347PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Reading</lt4:locationName>
+                                <lt4:crs>RDG</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Abbey Wood</lt7:locationName>
+                                    <lt7:crs>ABW</lt7:crs>
+                                    <lt7:st>17:21</lt7:st>
+                                    <lt7:at>17:24</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Woolwich (Elizabeth line)</lt7:locationName>
+                                    <lt7:crs>WWC</lt7:crs>
+                                    <lt7:st>17:24</lt7:st>
+                                    <lt7:at>17:27</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Custom House</lt7:locationName>
+                                    <lt7:crs>CUS</lt7:crs>
+                                    <lt7:st>17:28</lt7:st>
+                                    <lt7:at>17:31</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Canary Wharf (Elizabeth line)</lt7:locationName>
+                                    <lt7:crs>CWX</lt7:crs>
+                                    <lt7:st>17:32</lt7:st>
+                                    <lt7:at>17:35</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:36</lt7:st>
+                                    <lt7:at>17:54</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:39</lt7:st>
+                                    <lt7:at>17:57</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:41</lt7:st>
+                                    <lt7:at>17:59</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:44</lt7:st>
+                                    <lt7:at>18:02</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:46</lt7:st>
+                                    <lt7:et>18:04</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:52</lt4:sta>
+                        <lt4:eta>18:11</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by a late running train being in front of this one</lt4:delayReason>
+                        <lt4:serviceID>2382539PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shenfield</lt7:locationName>
+                                    <lt7:crs>SNF</lt7:crs>
+                                    <lt7:st>16:58</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Brentwood</lt7:locationName>
+                                    <lt7:crs>BRE</lt7:crs>
+                                    <lt7:st>17:02</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Harold Wood</lt7:locationName>
+                                    <lt7:crs>HRO</lt7:crs>
+                                    <lt7:st>17:06</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gidea Park</lt7:locationName>
+                                    <lt7:crs>GDP</lt7:crs>
+                                    <lt7:st>17:09</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Romford</lt7:locationName>
+                                    <lt7:crs>RMF</lt7:crs>
+                                    <lt7:st>17:12</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Chadwell Heath</lt7:locationName>
+                                    <lt7:crs>CTH</lt7:crs>
+                                    <lt7:st>17:15</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Goodmayes</lt7:locationName>
+                                    <lt7:crs>GMY</lt7:crs>
+                                    <lt7:st>17:17</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Seven Kings</lt7:locationName>
+                                    <lt7:crs>SVK</lt7:crs>
+                                    <lt7:st>17:19</lt7:st>
+                                    <lt7:at>17:23</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Ilford</lt7:locationName>
+                                    <lt7:crs>IFD</lt7:crs>
+                                    <lt7:st>17:23</lt7:st>
+                                    <lt7:at>17:29</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Manor Park</lt7:locationName>
+                                    <lt7:crs>MNP</lt7:crs>
+                                    <lt7:st>17:25</lt7:st>
+                                    <lt7:at>17:32</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Forest Gate</lt7:locationName>
+                                    <lt7:crs>FOG</lt7:crs>
+                                    <lt7:st>17:28</lt7:st>
+                                    <lt7:at>17:35</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Maryland</lt7:locationName>
+                                    <lt7:crs>MYL</lt7:crs>
+                                    <lt7:st>17:30</lt7:st>
+                                    <lt7:at>17:37</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stratford (London)</lt7:locationName>
+                                    <lt7:crs>SRA</lt7:crs>
+                                    <lt7:st>17:33</lt7:st>
+                                    <lt7:at>17:39</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:38</lt7:st>
+                                    <lt7:at>17:59</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:41</lt7:st>
+                                    <lt7:at>18:01</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:44</lt7:st>
+                                    <lt7:at>18:03</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:47</lt7:st>
+                                    <lt7:et>18:06</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:49</lt7:st>
+                                    <lt7:et>18:08</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:53</lt4:sta>
+                        <lt4:eta>18:25</lt4:eta>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by a fault on this train</lt4:delayReason>
+                        <lt4:serviceID>2382177PADTON__</lt4:serviceID>
+                        <lt5:rsid>XR398400</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Heathrow Airport T4</lt4:locationName>
+                                <lt4:crs>HAF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Heathrow Airport T4</lt7:locationName>
+                                    <lt7:crs>HAF</lt7:crs>
+                                    <lt7:st>17:15</lt7:st>
+                                    <lt7:at>17:45</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Heathrow Airport T123</lt7:locationName>
+                                    <lt7:crs>HXX</lt7:crs>
+                                    <lt7:st>17:21</lt7:st>
+                                    <lt7:at>17:51</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Hayes &amp; Harlington</lt7:locationName>
+                                    <lt7:crs>HAY</lt7:crs>
+                                    <lt7:st>17:27</lt7:st>
+                                    <lt7:at>Cancelled</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Southall</lt7:locationName>
+                                    <lt7:crs>STL</lt7:crs>
+                                    <lt7:st>17:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Hanwell</lt7:locationName>
+                                    <lt7:crs>HAN</lt7:crs>
+                                    <lt7:st>17:33</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>West Ealing</lt7:locationName>
+                                    <lt7:crs>WEA</lt7:crs>
+                                    <lt7:st>17:35</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Ealing Broadway</lt7:locationName>
+                                    <lt7:crs>EAL</lt7:crs>
+                                    <lt7:st>17:37</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Acton Main Line</lt7:locationName>
+                                    <lt7:crs>AML</lt7:crs>
+                                    <lt7:st>17:40</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Paddington</lt7:locationName>
+                                    <lt7:crs>PAD</lt7:crs>
+                                    <lt7:st>17:50</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:55</lt4:sta>
+                        <lt4:eta>18:09</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by damage to the overhead electric wires earlier today</lt4:delayReason>
+                        <lt4:serviceID>2381671PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Abbey Wood</lt4:locationName>
+                                <lt4:crs>ABW</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Heathrow Airport T4</lt4:locationName>
+                                <lt4:crs>HAF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Abbey Wood</lt7:locationName>
+                                    <lt7:crs>ABW</lt7:crs>
+                                    <lt7:st>17:26</lt7:st>
+                                    <lt7:at>17:30</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Woolwich (Elizabeth line)</lt7:locationName>
+                                    <lt7:crs>WWC</lt7:crs>
+                                    <lt7:st>17:29</lt7:st>
+                                    <lt7:at>17:33</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Custom House</lt7:locationName>
+                                    <lt7:crs>CUS</lt7:crs>
+                                    <lt7:st>17:33</lt7:st>
+                                    <lt7:at>17:37</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Canary Wharf (Elizabeth line)</lt7:locationName>
+                                    <lt7:crs>CWX</lt7:crs>
+                                    <lt7:st>17:37</lt7:st>
+                                    <lt7:at>17:40</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:41</lt7:st>
+                                    <lt7:at>17:57</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:44</lt7:st>
+                                    <lt7:at>18:00</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:46</lt7:st>
+                                    <lt7:at>18:02</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:49</lt7:st>
+                                    <lt7:et>18:04</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:51</lt7:st>
+                                    <lt7:et>18:06</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>17:57</lt4:sta>
+                        <lt4:eta>18:15</lt4:eta>
+                        <lt4:platform>B</lt4:platform>
+                        <lt4:operator>Elizabeth Line</lt4:operator>
+                        <lt4:operatorCode>XR</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2382544PADTLL__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Shenfield</lt4:locationName>
+                                <lt4:crs>SNF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shenfield</lt7:locationName>
+                                    <lt7:crs>SNF</lt7:crs>
+                                    <lt7:st>17:03</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Brentwood</lt7:locationName>
+                                    <lt7:crs>BRE</lt7:crs>
+                                    <lt7:st>17:07</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Harold Wood</lt7:locationName>
+                                    <lt7:crs>HRO</lt7:crs>
+                                    <lt7:st>17:11</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gidea Park</lt7:locationName>
+                                    <lt7:crs>GDP</lt7:crs>
+                                    <lt7:st>17:14</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Romford</lt7:locationName>
+                                    <lt7:crs>RMF</lt7:crs>
+                                    <lt7:st>17:17</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Chadwell Heath</lt7:locationName>
+                                    <lt7:crs>CTH</lt7:crs>
+                                    <lt7:st>17:20</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Goodmayes</lt7:locationName>
+                                    <lt7:crs>GMY</lt7:crs>
+                                    <lt7:st>17:22</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Seven Kings</lt7:locationName>
+                                    <lt7:crs>SVK</lt7:crs>
+                                    <lt7:st>17:24</lt7:st>
+                                    <lt7:at>17:26</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Ilford</lt7:locationName>
+                                    <lt7:crs>IFD</lt7:crs>
+                                    <lt7:st>17:28</lt7:st>
+                                    <lt7:at>17:31</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Manor Park</lt7:locationName>
+                                    <lt7:crs>MNP</lt7:crs>
+                                    <lt7:st>17:30</lt7:st>
+                                    <lt7:at>17:35</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Forest Gate</lt7:locationName>
+                                    <lt7:crs>FOG</lt7:crs>
+                                    <lt7:st>17:33</lt7:st>
+                                    <lt7:at>17:38</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Maryland</lt7:locationName>
+                                    <lt7:crs>MYL</lt7:crs>
+                                    <lt7:st>17:35</lt7:st>
+                                    <lt7:at>17:40</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stratford (London)</lt7:locationName>
+                                    <lt7:crs>SRA</lt7:crs>
+                                    <lt7:st>17:38</lt7:st>
+                                    <lt7:at>17:42</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Whitechapel</lt7:locationName>
+                                    <lt7:crs>ZLW</lt7:crs>
+                                    <lt7:st>17:43</lt7:st>
+                                    <lt7:at>18:02</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Liverpool Street</lt7:locationName>
+                                    <lt7:crs>LST</lt7:crs>
+                                    <lt7:st>17:46</lt7:st>
+                                    <lt7:at>18:04</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Farringdon</lt7:locationName>
+                                    <lt7:crs>ZFD</lt7:crs>
+                                    <lt7:st>17:49</lt7:st>
+                                    <lt7:et>18:07</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tottenham Court Road</lt7:locationName>
+                                    <lt7:crs>TCR</lt7:crs>
+                                    <lt7:st>17:52</lt7:st>
+                                    <lt7:et>18:10</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bond Street</lt7:locationName>
+                                    <lt7:crs>BDS</lt7:crs>
+                                    <lt7:st>17:54</lt7:st>
+                                    <lt7:et>18:12</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                </lt7:trainServices>
+            </GetStationBoardResult>
+        </GetArrBoardWithDetailsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getArrivalsDepartureBoard.xml
+++ b/test/fixtures/getArrivalsDepartureBoard.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetArrivalDepartureBoardResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T07:31:44.1620036+00:00</lt4:generatedAt>
+                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                <lt4:crs>BRI</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>Major disruption to / from London Paddington due to a damage to the overhead electric wires. Trains may be cancelled or severely delayed by at least 90 minutes. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/london-paddington-20231207/"&gt;Latest Travel News. &lt;/a&gt;</lt:message>
+                    <lt:message>
+    Due to heavy rain flooding the railway between Plymouth and Exeter St Davids trains may be cancelled, delayed or revised. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/totnes-20231208/"&gt;Latest Travel News&lt;/a&gt;.</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:trainServices>
+                    <lt7:service>
+                        <lt4:std>07:10</lt4:std>
+                        <lt4:etd>07:29</lt4:etd>
+                        <lt4:platform>8</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:delayReason>This train has been delayed by train crew being delayed by service disruption</lt4:delayReason>
+                        <lt4:serviceID>2391227BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Gloucester</lt4:locationName>
+                                <lt4:crs>GCR</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:28</lt4:sta>
+                        <lt4:eta>07:49</lt4:eta>
+                        <lt4:platform>13</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2392536BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Fratton</lt4:locationName>
+                                <lt4:crs>FTN</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:24</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:std>07:30</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>11</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2389786BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Weston-super-Mare</lt4:locationName>
+                                <lt4:crs>WSM</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:35</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>5</lt4:platform>
+                        <lt4:operator>CrossCountry</lt4:operator>
+                        <lt4:operatorCode>XC</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2394662BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>XC106000</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Edinburgh</lt4:locationName>
+                                <lt4:crs>EDB</lt4:crs>
+                                <lt4:via>via Leeds</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:36</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:std>07:38</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2386331BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>GW430300</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Penzance</lt4:locationName>
+                                <lt4:crs>PNZ</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:40</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>10</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391229BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Gloucester</lt4:locationName>
+                                <lt4:crs>GCR</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:40</lt4:std>
+                        <lt4:etd>07:52</lt4:etd>
+                        <lt4:platform>13</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391105BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Westbury</lt4:locationName>
+                                <lt4:crs>WSB</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:45</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391811BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Severn Beach</lt4:locationName>
+                                <lt4:crs>SVB</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:44</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:std>07:46</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>5</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391828BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Taunton</lt4:locationName>
+                                <lt4:crs>TAU</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Severn Beach</lt4:locationName>
+                                <lt4:crs>SVB</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:49</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2391145BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:48</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:std>07:52</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>10</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391152BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Gloucester</lt4:locationName>
+                                <lt4:crs>GCR</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Totnes</lt4:locationName>
+                                <lt4:crs>TOT</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:48</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:std>07:55</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2390193BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Frome</lt4:locationName>
+                                <lt4:crs>FRO</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:57</lt4:sta>
+                        <lt4:eta>08:02</lt4:eta>
+                        <lt4:platform>9</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391598BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Filton Abbey Wood</lt4:locationName>
+                                <lt4:crs>FIT</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:58</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>3</lt4:platform>
+                        <lt4:operator>CrossCountry</lt4:operator>
+                        <lt4:operatorCode>XC</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2383453BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>XC402000</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Manchester Piccadilly</lt4:locationName>
+                                <lt4:crs>MAN</lt4:crs>
+                                <lt4:via>via Stoke-on-Trent</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:52</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:std>08:00</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>11</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2389788BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Weston-super-Mare</lt4:locationName>
+                                <lt4:crs>WSM</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                </lt7:trainServices>
+            </GetStationBoardResult>
+        </GetArrivalDepartureBoardResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getArrivalsDepartureBoardWithDetails.xml
+++ b/test/fixtures/getArrivalsDepartureBoardWithDetails.xml
@@ -1,0 +1,1263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetArrDepBoardWithDetailsResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T07:33:00.1966348+00:00</lt4:generatedAt>
+                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                <lt4:crs>BRI</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>Major disruption to / from London Paddington due to a damage to the overhead electric wires. Trains may be cancelled or severely delayed by at least 90 minutes. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/london-paddington-20231207/"&gt;Latest Travel News. &lt;/a&gt;</lt:message>
+                    <lt:message>
+    Due to heavy rain flooding the railway between Plymouth and Exeter St Davids trains may be cancelled, delayed or revised. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/totnes-20231208/"&gt;Latest Travel News&lt;/a&gt;.</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:trainServices>
+                    <lt7:service>
+                        <lt4:sta>07:28</lt4:sta>
+                        <lt4:eta>07:49</lt4:eta>
+                        <lt4:platform>13</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2392536BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Fratton</lt4:locationName>
+                                <lt4:crs>FTN</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Fratton</lt7:locationName>
+                                    <lt7:crs>FTN</lt7:crs>
+                                    <lt7:st>04:50</lt7:st>
+                                    <lt7:at>05:15</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cosham</lt7:locationName>
+                                    <lt7:crs>CSA</lt7:crs>
+                                    <lt7:st>04:59</lt7:st>
+                                    <lt7:at>05:23</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Portchester</lt7:locationName>
+                                    <lt7:crs>PTC</lt7:crs>
+                                    <lt7:st>05:04</lt7:st>
+                                    <lt7:at>05:29</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Fareham</lt7:locationName>
+                                    <lt7:crs>FRM</lt7:crs>
+                                    <lt7:st>05:10</lt7:st>
+                                    <lt7:at>05:35</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Southampton Central</lt7:locationName>
+                                    <lt7:crs>SOU</lt7:crs>
+                                    <lt7:st>05:33</lt7:st>
+                                    <lt7:at>06:00</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Romsey</lt7:locationName>
+                                    <lt7:crs>ROM</lt7:crs>
+                                    <lt7:st>05:45</lt7:st>
+                                    <lt7:at>06:12</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Salisbury</lt7:locationName>
+                                    <lt7:crs>SAL</lt7:crs>
+                                    <lt7:st>06:06</lt7:st>
+                                    <lt7:at>06:31</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Warminster</lt7:locationName>
+                                    <lt7:crs>WMN</lt7:crs>
+                                    <lt7:st>06:27</lt7:st>
+                                    <lt7:at>06:52</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Dilton Marsh</lt7:locationName>
+                                    <lt7:crs>DMH</lt7:crs>
+                                    <lt7:st>06:31</lt7:st>
+                                    <lt7:at>06:58</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Westbury</lt7:locationName>
+                                    <lt7:crs>WSB</lt7:crs>
+                                    <lt7:st>06:40</lt7:st>
+                                    <lt7:at>07:03</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Trowbridge</lt7:locationName>
+                                    <lt7:crs>TRO</lt7:crs>
+                                    <lt7:st>06:46</lt7:st>
+                                    <lt7:at>07:10</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bradford-on-Avon</lt7:locationName>
+                                    <lt7:crs>BOA</lt7:crs>
+                                    <lt7:st>06:52</lt7:st>
+                                    <lt7:at>07:17</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Avoncliff</lt7:locationName>
+                                    <lt7:crs>AVF</lt7:crs>
+                                    <lt7:st>06:55</lt7:st>
+                                    <lt7:at>07:20</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Freshford</lt7:locationName>
+                                    <lt7:crs>FFD</lt7:crs>
+                                    <lt7:st>06:58</lt7:st>
+                                    <lt7:at>07:23</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bath Spa</lt7:locationName>
+                                    <lt7:crs>BTH</lt7:crs>
+                                    <lt7:st>07:10</lt7:st>
+                                    <lt7:et>07:34</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Oldfield Park</lt7:locationName>
+                                    <lt7:crs>OLF</lt7:crs>
+                                    <lt7:st>07:13</lt7:st>
+                                    <lt7:et>07:36</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Keynsham</lt7:locationName>
+                                    <lt7:crs>KYN</lt7:crs>
+                                    <lt7:st>07:20</lt7:st>
+                                    <lt7:et>07:43</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:35</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>5</lt4:platform>
+                        <lt4:operator>CrossCountry</lt4:operator>
+                        <lt4:operatorCode>XC</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2394662BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>XC106000</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Edinburgh</lt4:locationName>
+                                <lt4:crs>EDB</lt4:crs>
+                                <lt4:via>via Leeds</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bristol Parkway</lt7:locationName>
+                                    <lt7:crs>BPW</lt7:crs>
+                                    <lt7:st>07:43</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cheltenham Spa</lt7:locationName>
+                                    <lt7:crs>CNM</lt7:crs>
+                                    <lt7:st>08:13</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Worcestershire Parkway</lt7:locationName>
+                                    <lt7:crs>WOP</lt7:crs>
+                                    <lt7:st>08:28</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Birmingham New Street</lt7:locationName>
+                                    <lt7:crs>BHM</lt7:crs>
+                                    <lt7:st>08:55</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Burton-on-Trent</lt7:locationName>
+                                    <lt7:crs>BUT</lt7:crs>
+                                    <lt7:st>09:24</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Derby</lt7:locationName>
+                                    <lt7:crs>DBY</lt7:crs>
+                                    <lt7:st>09:36</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Sheffield</lt7:locationName>
+                                    <lt7:crs>SHF</lt7:crs>
+                                    <lt7:st>10:17</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Wakefield Westgate</lt7:locationName>
+                                    <lt7:crs>WKF</lt7:crs>
+                                    <lt7:st>10:48</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Leeds</lt7:locationName>
+                                    <lt7:crs>LDS</lt7:crs>
+                                    <lt7:st>11:03</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>York</lt7:locationName>
+                                    <lt7:crs>YRK</lt7:crs>
+                                    <lt7:st>11:30</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Darlington</lt7:locationName>
+                                    <lt7:crs>DAR</lt7:crs>
+                                    <lt7:st>11:58</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Durham</lt7:locationName>
+                                    <lt7:crs>DHM</lt7:crs>
+                                    <lt7:st>12:15</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newcastle</lt7:locationName>
+                                    <lt7:crs>NCL</lt7:crs>
+                                    <lt7:st>12:29</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Morpeth</lt7:locationName>
+                                    <lt7:crs>MPT</lt7:crs>
+                                    <lt7:st>12:48</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Berwick-upon-Tweed</lt7:locationName>
+                                    <lt7:crs>BWK</lt7:crs>
+                                    <lt7:st>13:21</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>ABHLJN</lt7:locationName>
+                                    <lt7:crs>???</lt7:crs>
+                                    <lt7:st>14:04</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Edinburgh</lt7:locationName>
+                                    <lt7:crs>EDB</lt7:crs>
+                                    <lt7:st>14:09</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:36</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:std>07:38</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2386331BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>GW430300</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Penzance</lt4:locationName>
+                                <lt4:crs>PNZ</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Paddington</lt7:locationName>
+                                    <lt7:crs>PAD</lt7:crs>
+                                    <lt7:st>06:00</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Reading</lt7:locationName>
+                                    <lt7:crs>RDG</lt7:crs>
+                                    <lt7:st>06:27</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Didcot Parkway</lt7:locationName>
+                                    <lt7:crs>DID</lt7:crs>
+                                    <lt7:st>06:40</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Swindon</lt7:locationName>
+                                    <lt7:crs>SWI</lt7:crs>
+                                    <lt7:st>06:59</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Chippenham</lt7:locationName>
+                                    <lt7:crs>CPM</lt7:crs>
+                                    <lt7:st>07:11</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bath Spa</lt7:locationName>
+                                    <lt7:crs>BTH</lt7:crs>
+                                    <lt7:st>07:24</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bridgwater</lt7:locationName>
+                                    <lt7:crs>BWT</lt7:crs>
+                                    <lt7:st>08:04</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Taunton</lt7:locationName>
+                                    <lt7:crs>TAU</lt7:crs>
+                                    <lt7:st>08:15</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tiverton Parkway</lt7:locationName>
+                                    <lt7:crs>TVP</lt7:crs>
+                                    <lt7:st>08:28</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Exeter St Davids</lt7:locationName>
+                                    <lt7:crs>EXD</lt7:crs>
+                                    <lt7:st>08:42</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newton Abbot</lt7:locationName>
+                                    <lt7:crs>NTA</lt7:crs>
+                                    <lt7:st>09:04</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Plymouth</lt7:locationName>
+                                    <lt7:crs>PLY</lt7:crs>
+                                    <lt7:st>09:39</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Saltash</lt7:locationName>
+                                    <lt7:crs>STS</lt7:crs>
+                                    <lt7:st>09:53</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Germans</lt7:locationName>
+                                    <lt7:crs>SGM</lt7:crs>
+                                    <lt7:st>10:00</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Liskeard</lt7:locationName>
+                                    <lt7:crs>LSK</lt7:crs>
+                                    <lt7:st>10:12</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bodmin Parkway</lt7:locationName>
+                                    <lt7:crs>BOD</lt7:crs>
+                                    <lt7:st>10:25</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lostwithiel</lt7:locationName>
+                                    <lt7:crs>LOS</lt7:crs>
+                                    <lt7:st>10:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Austell</lt7:locationName>
+                                    <lt7:crs>SAU</lt7:crs>
+                                    <lt7:st>10:42</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Truro</lt7:locationName>
+                                    <lt7:crs>TRU</lt7:crs>
+                                    <lt7:st>10:59</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Redruth</lt7:locationName>
+                                    <lt7:crs>RED</lt7:crs>
+                                    <lt7:st>11:11</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Camborne</lt7:locationName>
+                                    <lt7:crs>CBN</lt7:crs>
+                                    <lt7:st>11:18</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Hayle</lt7:locationName>
+                                    <lt7:crs>HYL</lt7:crs>
+                                    <lt7:st>11:26</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Erth</lt7:locationName>
+                                    <lt7:crs>SER</lt7:crs>
+                                    <lt7:st>11:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Penzance</lt7:locationName>
+                                    <lt7:crs>PNZ</lt7:crs>
+                                    <lt7:st>11:40</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:40</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>10</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391229BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Gloucester</lt4:locationName>
+                                <lt4:crs>GCR</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>07:47</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bristol Parkway</lt7:locationName>
+                                    <lt7:crs>BPW</lt7:crs>
+                                    <lt7:st>07:51</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yate</lt7:locationName>
+                                    <lt7:crs>YAE</lt7:crs>
+                                    <lt7:st>08:00</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cam &amp; Dursley</lt7:locationName>
+                                    <lt7:crs>CDU</lt7:crs>
+                                    <lt7:st>08:13</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gloucester</lt7:locationName>
+                                    <lt7:crs>GCR</lt7:crs>
+                                    <lt7:st>08:30</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:40</lt4:std>
+                        <lt4:etd>07:52</lt4:etd>
+                        <lt4:platform>13</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391105BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Westbury</lt4:locationName>
+                                <lt4:crs>WSB</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Keynsham</lt7:locationName>
+                                    <lt7:crs>KYN</lt7:crs>
+                                    <lt7:st>07:46</lt7:st>
+                                    <lt7:et>07:58</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Oldfield Park</lt7:locationName>
+                                    <lt7:crs>OLF</lt7:crs>
+                                    <lt7:st>07:53</lt7:st>
+                                    <lt7:et>08:05</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bath Spa</lt7:locationName>
+                                    <lt7:crs>BTH</lt7:crs>
+                                    <lt7:st>07:56</lt7:st>
+                                    <lt7:et>08:08</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Freshford</lt7:locationName>
+                                    <lt7:crs>FFD</lt7:crs>
+                                    <lt7:st>08:07</lt7:st>
+                                    <lt7:et>08:17</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Avoncliff</lt7:locationName>
+                                    <lt7:crs>AVF</lt7:crs>
+                                    <lt7:st>08:10</lt7:st>
+                                    <lt7:et>08:20</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bradford-on-Avon</lt7:locationName>
+                                    <lt7:crs>BOA</lt7:crs>
+                                    <lt7:st>08:14</lt7:st>
+                                    <lt7:et>08:23</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Trowbridge</lt7:locationName>
+                                    <lt7:crs>TRO</lt7:crs>
+                                    <lt7:st>08:20</lt7:st>
+                                    <lt7:et>08:29</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Westbury</lt7:locationName>
+                                    <lt7:crs>WSB</lt7:crs>
+                                    <lt7:st>08:28</lt7:st>
+                                    <lt7:et>08:36</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:45</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391811BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Severn Beach</lt4:locationName>
+                                <lt4:crs>SVB</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Severn Beach</lt7:locationName>
+                                    <lt7:crs>SVB</lt7:crs>
+                                    <lt7:st>07:01</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Andrews Road</lt7:locationName>
+                                    <lt7:crs>SAR</lt7:crs>
+                                    <lt7:st>07:07</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Avonmouth</lt7:locationName>
+                                    <lt7:crs>AVN</lt7:crs>
+                                    <lt7:st>07:12</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Portway Park and Ride</lt7:locationName>
+                                    <lt7:crs>PRI</lt7:crs>
+                                    <lt7:st>07:14</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shirehampton</lt7:locationName>
+                                    <lt7:crs>SHH</lt7:crs>
+                                    <lt7:st>07:16</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Sea Mills</lt7:locationName>
+                                    <lt7:crs>SML</lt7:crs>
+                                    <lt7:st>07:20</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Clifton Down</lt7:locationName>
+                                    <lt7:crs>CFN</lt7:crs>
+                                    <lt7:st>07:26</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Redland</lt7:locationName>
+                                    <lt7:crs>RDA</lt7:crs>
+                                    <lt7:st>07:28</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Montpelier</lt7:locationName>
+                                    <lt7:crs>MTP</lt7:crs>
+                                    <lt7:st>07:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stapleton Road</lt7:locationName>
+                                    <lt7:crs>SRD</lt7:crs>
+                                    <lt7:st>07:36</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lawrence Hill</lt7:locationName>
+                                    <lt7:crs>LWH</lt7:crs>
+                                    <lt7:st>07:40</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:44</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:std>07:46</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>5</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391828BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Taunton</lt4:locationName>
+                                <lt4:crs>TAU</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Severn Beach</lt4:locationName>
+                                <lt4:crs>SVB</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Taunton</lt7:locationName>
+                                    <lt7:crs>TAU</lt7:crs>
+                                    <lt7:st>06:37</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bridgwater</lt7:locationName>
+                                    <lt7:crs>BWT</lt7:crs>
+                                    <lt7:st>06:48</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Highbridge &amp; Burnham</lt7:locationName>
+                                    <lt7:crs>HIG</lt7:crs>
+                                    <lt7:st>06:55</lt7:st>
+                                    <lt7:at>06:57</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston-super-Mare</lt7:locationName>
+                                    <lt7:crs>WSM</lt7:crs>
+                                    <lt7:st>07:10</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston Milton</lt7:locationName>
+                                    <lt7:crs>WNM</lt7:crs>
+                                    <lt7:st>07:13</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Worle</lt7:locationName>
+                                    <lt7:crs>WOR</lt7:crs>
+                                    <lt7:st>07:17</lt7:st>
+                                    <lt7:at>07:18</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yatton</lt7:locationName>
+                                    <lt7:crs>YAT</lt7:crs>
+                                    <lt7:st>07:23</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Nailsea &amp; Backwell</lt7:locationName>
+                                    <lt7:crs>NLS</lt7:crs>
+                                    <lt7:st>07:29</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Parson Street</lt7:locationName>
+                                    <lt7:crs>PSN</lt7:crs>
+                                    <lt7:st>07:37</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bedminster</lt7:locationName>
+                                    <lt7:crs>BMT</lt7:crs>
+                                    <lt7:st>07:40</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lawrence Hill</lt7:locationName>
+                                    <lt7:crs>LWH</lt7:crs>
+                                    <lt7:st>07:49</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stapleton Road</lt7:locationName>
+                                    <lt7:crs>SRD</lt7:crs>
+                                    <lt7:st>07:51</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Montpelier</lt7:locationName>
+                                    <lt7:crs>MTP</lt7:crs>
+                                    <lt7:st>07:55</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Redland</lt7:locationName>
+                                    <lt7:crs>RDA</lt7:crs>
+                                    <lt7:st>07:57</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Clifton Down</lt7:locationName>
+                                    <lt7:crs>CFN</lt7:crs>
+                                    <lt7:st>08:00</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Sea Mills</lt7:locationName>
+                                    <lt7:crs>SML</lt7:crs>
+                                    <lt7:st>08:04</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shirehampton</lt7:locationName>
+                                    <lt7:crs>SHH</lt7:crs>
+                                    <lt7:st>08:08</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Portway Park and Ride</lt7:locationName>
+                                    <lt7:crs>PRI</lt7:crs>
+                                    <lt7:st>08:10</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Avonmouth</lt7:locationName>
+                                    <lt7:crs>AVN</lt7:crs>
+                                    <lt7:st>08:12</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Andrews Road</lt7:locationName>
+                                    <lt7:crs>SAR</lt7:crs>
+                                    <lt7:st>08:16</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Severn Beach</lt7:locationName>
+                                    <lt7:crs>SVB</lt7:crs>
+                                    <lt7:st>08:23</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:49</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2391145BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cardiff Central</lt7:locationName>
+                                    <lt7:crs>CDF</lt7:crs>
+                                    <lt7:st>06:57</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newport (South Wales)</lt7:locationName>
+                                    <lt7:crs>NWP</lt7:crs>
+                                    <lt7:st>07:10</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Severn Tunnel Junction</lt7:locationName>
+                                    <lt7:crs>STJ</lt7:crs>
+                                    <lt7:st>07:21</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Patchway</lt7:locationName>
+                                    <lt7:crs>PWY</lt7:crs>
+                                    <lt7:st>07:32</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>07:37</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:48</lt4:sta>
+                        <lt4:eta>On time</lt4:eta>
+                        <lt4:std>07:52</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>10</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391152BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Gloucester</lt4:locationName>
+                                <lt4:crs>GCR</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Totnes</lt4:locationName>
+                                <lt4:crs>TOT</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gloucester</lt7:locationName>
+                                    <lt7:crs>GCR</lt7:crs>
+                                    <lt7:st>07:00</lt7:st>
+                                    <lt7:at>On time</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cam &amp; Dursley</lt7:locationName>
+                                    <lt7:crs>CDU</lt7:crs>
+                                    <lt7:st>07:12</lt7:st>
+                                    <lt7:at>07:14</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yate</lt7:locationName>
+                                    <lt7:crs>YAE</lt7:crs>
+                                    <lt7:st>07:25</lt7:st>
+                                    <lt7:at>07:27</lt7:at>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bristol Parkway</lt7:locationName>
+                                    <lt7:crs>BPW</lt7:crs>
+                                    <lt7:st>07:34</lt7:st>
+                                    <lt7:et>07:36</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>07:38</lt7:st>
+                                    <lt7:et>07:39</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bedminster</lt7:locationName>
+                                    <lt7:crs>BMT</lt7:crs>
+                                    <lt7:st>07:55</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Parson Street</lt7:locationName>
+                                    <lt7:crs>PSN</lt7:crs>
+                                    <lt7:st>07:58</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Nailsea &amp; Backwell</lt7:locationName>
+                                    <lt7:crs>NLS</lt7:crs>
+                                    <lt7:st>08:05</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yatton</lt7:locationName>
+                                    <lt7:crs>YAT</lt7:crs>
+                                    <lt7:st>08:11</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Worle</lt7:locationName>
+                                    <lt7:crs>WOR</lt7:crs>
+                                    <lt7:st>08:17</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston Milton</lt7:locationName>
+                                    <lt7:crs>WNM</lt7:crs>
+                                    <lt7:st>08:22</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston-super-Mare</lt7:locationName>
+                                    <lt7:crs>WSM</lt7:crs>
+                                    <lt7:st>08:26</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Highbridge &amp; Burnham</lt7:locationName>
+                                    <lt7:crs>HIG</lt7:crs>
+                                    <lt7:st>08:38</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bridgwater</lt7:locationName>
+                                    <lt7:crs>BWT</lt7:crs>
+                                    <lt7:st>08:45</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Taunton</lt7:locationName>
+                                    <lt7:crs>TAU</lt7:crs>
+                                    <lt7:st>08:55</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tiverton Parkway</lt7:locationName>
+                                    <lt7:crs>TVP</lt7:crs>
+                                    <lt7:st>09:08</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Exeter St Davids</lt7:locationName>
+                                    <lt7:crs>EXD</lt7:crs>
+                                    <lt7:st>09:23</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Dawlish</lt7:locationName>
+                                    <lt7:crs>DWL</lt7:crs>
+                                    <lt7:st>09:36</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Teignmouth</lt7:locationName>
+                                    <lt7:crs>TGM</lt7:crs>
+                                    <lt7:st>09:41</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newton Abbot</lt7:locationName>
+                                    <lt7:crs>NTA</lt7:crs>
+                                    <lt7:st>09:49</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Totnes</lt7:locationName>
+                                    <lt7:crs>TOT</lt7:crs>
+                                    <lt7:st>10:01</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Ivybridge</lt7:locationName>
+                                    <lt7:crs>IVY</lt7:crs>
+                                    <lt7:st>10:16</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Plymouth</lt7:locationName>
+                                    <lt7:crs>PLY</lt7:crs>
+                                    <lt7:st>10:31</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Budeaux Ferry Road</lt7:locationName>
+                                    <lt7:crs>SBF</lt7:crs>
+                                    <lt7:st>10:48</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Saltash</lt7:locationName>
+                                    <lt7:crs>STS</lt7:crs>
+                                    <lt7:st>10:53</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Germans</lt7:locationName>
+                                    <lt7:crs>SGM</lt7:crs>
+                                    <lt7:st>11:00</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Liskeard</lt7:locationName>
+                                    <lt7:crs>LSK</lt7:crs>
+                                    <lt7:st>11:12</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bodmin Parkway</lt7:locationName>
+                                    <lt7:crs>BOD</lt7:crs>
+                                    <lt7:st>11:24</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lostwithiel</lt7:locationName>
+                                    <lt7:crs>LOS</lt7:crs>
+                                    <lt7:st>11:29</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Par</lt7:locationName>
+                                    <lt7:crs>PAR</lt7:crs>
+                                    <lt7:st>11:36</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Austell</lt7:locationName>
+                                    <lt7:crs>SAU</lt7:crs>
+                                    <lt7:st>11:43</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Truro</lt7:locationName>
+                                    <lt7:crs>TRU</lt7:crs>
+                                    <lt7:st>12:00</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Redruth</lt7:locationName>
+                                    <lt7:crs>RED</lt7:crs>
+                                    <lt7:st>12:12</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Camborne</lt7:locationName>
+                                    <lt7:crs>CBN</lt7:crs>
+                                    <lt7:st>12:18</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Hayle</lt7:locationName>
+                                    <lt7:crs>HYL</lt7:crs>
+                                    <lt7:st>12:27</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>St Erth</lt7:locationName>
+                                    <lt7:crs>SER</lt7:crs>
+                                    <lt7:st>12:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Penzance</lt7:locationName>
+                                    <lt7:crs>PNZ</lt7:crs>
+                                    <lt7:st>12:40</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:sta>07:48</lt4:sta>
+                        <lt4:eta>Cancelled</lt4:eta>
+                        <lt4:std>07:55</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2390193BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Frome</lt4:locationName>
+                                <lt4:crs>FRO</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:previousCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Frome</lt7:locationName>
+                                    <lt7:crs>FRO</lt7:crs>
+                                    <lt7:st>06:42</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Westbury</lt7:locationName>
+                                    <lt7:crs>WSB</lt7:crs>
+                                    <lt7:st>06:59</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Trowbridge</lt7:locationName>
+                                    <lt7:crs>TRO</lt7:crs>
+                                    <lt7:st>07:05</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bradford-on-Avon</lt7:locationName>
+                                    <lt7:crs>BOA</lt7:crs>
+                                    <lt7:st>07:11</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Avoncliff</lt7:locationName>
+                                    <lt7:crs>AVF</lt7:crs>
+                                    <lt7:st>07:15</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Freshford</lt7:locationName>
+                                    <lt7:crs>FFD</lt7:crs>
+                                    <lt7:st>07:18</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bath Spa</lt7:locationName>
+                                    <lt7:crs>BTH</lt7:crs>
+                                    <lt7:st>07:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Oldfield Park</lt7:locationName>
+                                    <lt7:crs>OLF</lt7:crs>
+                                    <lt7:st>07:33</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Keynsham</lt7:locationName>
+                                    <lt7:crs>KYN</lt7:crs>
+                                    <lt7:st>07:40</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:previousCallingPoints>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>08:02</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Patchway</lt7:locationName>
+                                    <lt7:crs>PWY</lt7:crs>
+                                    <lt7:st>08:10</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Severn Tunnel Junction</lt7:locationName>
+                                    <lt7:crs>STJ</lt7:crs>
+                                    <lt7:st>08:21</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newport (South Wales)</lt7:locationName>
+                                    <lt7:crs>NWP</lt7:crs>
+                                    <lt7:st>08:33</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cardiff Central</lt7:locationName>
+                                    <lt7:crs>CDF</lt7:crs>
+                                    <lt7:st>08:47</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                </lt7:trainServices>
+            </GetStationBoardResult>
+        </GetArrDepBoardWithDetailsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getDepartureBoard.xml
+++ b/test/fixtures/getDepartureBoard.xml
@@ -1,0 +1,730 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetDepartureBoardResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T07:20:27.1211921+00:00</lt4:generatedAt>
+                <lt4:locationName>London Euston</lt4:locationName>
+                <lt4:crs>EUS</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>&lt;p&gt;
+Severe weather between Crianlarich and Oban / Mallaig means some lines are disrupted. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/crianlarich-20231207/"&gt;Latest Travel News&lt;/a&gt;.&lt;/p&gt;</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:trainServices>
+                    <lt7:service>
+                        <lt4:std>07:23</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>12</lt4:platform>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2395130EUSTON__</lt4:serviceID>
+                        <lt5:rsid>LM200900</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Birmingham New Street</lt4:locationName>
+                                <lt4:crs>BHM</lt4:crs>
+                                <lt4:via>via Northampton</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="A1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="A2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:24</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>8</lt4:platform>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2396576EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Tring</lt4:locationName>
+                                <lt4:crs>TRI</lt4:crs>
+                                <lt4:via>via Watford Junction</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:28</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>9</lt4:platform>
+                        <lt4:operator>London Overground</lt4:operator>
+                        <lt4:operatorCode>LO</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2383445EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Watford Junction</lt4:locationName>
+                                <lt4:crs>WFJ</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:30</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>13</lt4:platform>
+                        <lt4:operator>Avanti West Coast</lt4:operator>
+                        <lt4:operatorCode>VT</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2403177EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Glasgow Central</lt4:locationName>
+                                <lt4:crs>GLC</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="5">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="6">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="7">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="8">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="9">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:33</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>16</lt4:platform>
+                        <lt4:operator>Avanti West Coast</lt4:operator>
+                        <lt4:operatorCode>VT</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2403478EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Manchester Piccadilly</lt4:locationName>
+                                <lt4:crs>MAN</lt4:crs>
+                                <lt4:via>via Wilmslow</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="5">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="6">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="7">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="8">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="9">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="10">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="11">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:34</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2396580EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Tring</lt4:locationName>
+                                <lt4:crs>TRI</lt4:crs>
+                                <lt4:via>via Watford Junction</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="A1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="A2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:39</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2395819EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Milton Keynes Central</lt4:locationName>
+                                <lt4:crs>MKC</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:43</lt4:std>
+                        <lt4:etd>07:45</lt4:etd>
+                        <lt4:operator>Avanti West Coast</lt4:operator>
+                        <lt4:operatorCode>VT</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2402944EUSTON__</lt4:serviceID>
+                        <lt5:rsid>VT806000</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Liverpool Lime Street</lt4:locationName>
+                                <lt4:crs>LIV</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="1">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="2">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="3">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="4">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="5">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="6">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="7">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="8">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="9">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="10">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="11">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:45</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>London Overground</lt4:operator>
+                        <lt4:operatorCode>LO</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2383450EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Watford Junction</lt4:locationName>
+                                <lt4:crs>WFJ</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:46</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2395046EUSTON__</lt4:serviceID>
+                        <lt5:rsid>LM101300</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Crewe</lt4:locationName>
+                                <lt4:crs>CRE</lt4:crs>
+                                <lt4:via>via Nuneaton &amp; Stafford</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="A1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="A2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:53</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>Avanti West Coast</lt4:operator>
+                        <lt4:operatorCode>VT</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2402975EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Manchester Piccadilly</lt4:locationName>
+                                <lt4:crs>MAN</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="1">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="2">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="3">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="4">
+                                    <lt7:coachClass>First</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="5">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="6">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="7">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="8">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="9">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="10">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="11">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:54</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2396584EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Tring</lt4:locationName>
+                                <lt4:crs>TRI</lt4:crs>
+                                <lt4:via>via Watford Junction</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="A1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="A2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:56</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2384304EUSTON__</lt4:serviceID>
+                        <lt5:rsid>LM201300</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Birmingham New Street</lt4:locationName>
+                                <lt4:crs>BHM</lt4:crs>
+                                <lt4:via>via Northampton</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="A1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="A2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>07:58</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>London Overground</lt4:operator>
+                        <lt4:operatorCode>LO</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2383454EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Watford Junction</lt4:locationName>
+                                <lt4:crs>WFJ</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>08:09</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:operator>West Midlands Trains</lt4:operator>
+                        <lt4:operatorCode>LM</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2395823EUSTON__</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Euston</lt4:locationName>
+                                <lt4:crs>EUS</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Milton Keynes Central</lt4:locationName>
+                                <lt4:crs>MKC</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:formation>
+                            <lt7:coaches>
+                                <lt7:coach number="A1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="A2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="A4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B1">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                                <lt7:coach number="B2">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Accessible</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B3">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                    <lt7:toilet>Standard</lt7:toilet>
+                                </lt7:coach>
+                                <lt7:coach number="B4">
+                                    <lt7:coachClass>Standard</lt7:coachClass>
+                                </lt7:coach>
+                            </lt7:coaches>
+                        </lt7:formation>
+                    </lt7:service>
+                </lt7:trainServices>
+            </GetStationBoardResult>
+        </GetDepartureBoardResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getDepartureBoardWithDetails.xml
+++ b/test/fixtures/getDepartureBoardWithDetails.xml
@@ -1,0 +1,699 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetDepBoardWithDetailsResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetStationBoardResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T18:14:06.4172305+00:00</lt4:generatedAt>
+                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                <lt4:crs>BRI</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>Lines have reopened following yesterday's damage to the overhead electric wires near London Paddington. Trains may still be cancelled or delayed. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/london-paddington-20231207/"&gt;Latest Travel News. &lt;/a&gt;</lt:message>
+                    <lt:message>
+    Due to heavy rain flooding the railway earlier today between Plymouth and Exeter St Davids trains may be cancelled, delayed or revised. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/totnes-20231208/"&gt;Latest Travel News&lt;/a&gt;.</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:trainServices>
+                    <lt7:service>
+                        <lt4:std>17:57</lt4:std>
+                        <lt4:etd>18:14</lt4:etd>
+                        <lt4:platform>7</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2390247BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Portsmouth Harbour</lt4:locationName>
+                                <lt4:crs>PMH</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>18:04</lt7:st>
+                                    <lt7:et>18:21</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Severn Tunnel Junction</lt7:locationName>
+                                    <lt7:crs>STJ</lt7:crs>
+                                    <lt7:st>18:21</lt7:st>
+                                    <lt7:et>18:33</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newport (South Wales)</lt7:locationName>
+                                    <lt7:crs>NWP</lt7:crs>
+                                    <lt7:st>18:33</lt7:st>
+                                    <lt7:et>18:44</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cardiff Central</lt7:locationName>
+                                    <lt7:crs>CDF</lt7:crs>
+                                    <lt7:st>18:46</lt7:st>
+                                    <lt7:et>18:56</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:04</lt4:std>
+                        <lt4:etd>Delayed</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2391638BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Filton Abbey Wood</lt4:locationName>
+                                <lt4:crs>FIT</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lawrence Hill</lt7:locationName>
+                                    <lt7:crs>LWH</lt7:crs>
+                                    <lt7:st>18:07</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stapleton Road</lt7:locationName>
+                                    <lt7:crs>SRD</lt7:crs>
+                                    <lt7:st>18:09</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>18:17</lt7:st>
+                                    <lt7:et>Delayed</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:10</lt4:std>
+                        <lt4:etd>18:14</lt4:etd>
+                        <lt4:platform>11</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2387782BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>GW891000</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Weymouth</lt4:locationName>
+                                <lt4:crs>WEY</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Gloucester</lt4:locationName>
+                                <lt4:crs>GCR</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>18:17</lt7:st>
+                                    <lt7:et>18:20</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bristol Parkway</lt7:locationName>
+                                    <lt7:crs>BPW</lt7:crs>
+                                    <lt7:st>18:21</lt7:st>
+                                    <lt7:et>18:24</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yate</lt7:locationName>
+                                    <lt7:crs>YAE</lt7:crs>
+                                    <lt7:st>18:31</lt7:st>
+                                    <lt7:et>18:33</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Gloucester</lt7:locationName>
+                                    <lt7:crs>GCR</lt7:crs>
+                                    <lt7:st>19:03</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:12</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of a shortage of train crew</lt4:cancelReason>
+                        <lt4:serviceID>2391955BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Avonmouth</lt4:locationName>
+                                <lt4:crs>AVN</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lawrence Hill</lt7:locationName>
+                                    <lt7:crs>LWH</lt7:crs>
+                                    <lt7:st>18:15</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stapleton Road</lt7:locationName>
+                                    <lt7:crs>SRD</lt7:crs>
+                                    <lt7:st>18:17</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Montpelier</lt7:locationName>
+                                    <lt7:crs>MTP</lt7:crs>
+                                    <lt7:st>18:21</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Redland</lt7:locationName>
+                                    <lt7:crs>RDA</lt7:crs>
+                                    <lt7:st>18:23</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Clifton Down</lt7:locationName>
+                                    <lt7:crs>CFN</lt7:crs>
+                                    <lt7:st>18:26</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Sea Mills</lt7:locationName>
+                                    <lt7:crs>SML</lt7:crs>
+                                    <lt7:st>18:31</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Shirehampton</lt7:locationName>
+                                    <lt7:crs>SHH</lt7:crs>
+                                    <lt7:st>18:34</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Portway Park and Ride</lt7:locationName>
+                                    <lt7:crs>PRI</lt7:crs>
+                                    <lt7:st>18:36</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Avonmouth</lt7:locationName>
+                                    <lt7:crs>AVN</lt7:crs>
+                                    <lt7:st>18:39</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:15</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2386319BRSTLTM_</lt4:serviceID>
+                        <lt5:rsid>GW434500</lt5:rsid>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>London Paddington</lt4:locationName>
+                                <lt4:crs>PAD</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Taunton</lt4:locationName>
+                                <lt4:crs>TAU</lt4:crs>
+                                <lt4:via>via Weston-super-Mare</lt4:via>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt5:currentDestinations>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:currentDestinations>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Nailsea &amp; Backwell</lt7:locationName>
+                                    <lt7:crs>NLS</lt7:crs>
+                                    <lt7:st>18:24</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yatton</lt7:locationName>
+                                    <lt7:crs>YAT</lt7:crs>
+                                    <lt7:st>18:29</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Worle</lt7:locationName>
+                                    <lt7:crs>WOR</lt7:crs>
+                                    <lt7:st>18:35</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston-super-Mare</lt7:locationName>
+                                    <lt7:crs>WSM</lt7:crs>
+                                    <lt7:st>18:42</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Highbridge &amp; Burnham</lt7:locationName>
+                                    <lt7:crs>HIG</lt7:crs>
+                                    <lt7:st>18:53</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bridgwater</lt7:locationName>
+                                    <lt7:crs>BWT</lt7:crs>
+                                    <lt7:st>19:00</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Taunton</lt7:locationName>
+                                    <lt7:crs>TAU</lt7:crs>
+                                    <lt7:st>19:12</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:22</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>7</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2390255BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Portsmouth Harbour</lt4:locationName>
+                                <lt4:crs>PMH</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Keynsham</lt7:locationName>
+                                    <lt7:crs>KYN</lt7:crs>
+                                    <lt7:st>18:28</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bath Spa</lt7:locationName>
+                                    <lt7:crs>BTH</lt7:crs>
+                                    <lt7:st>18:36</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bradford-on-Avon</lt7:locationName>
+                                    <lt7:crs>BOA</lt7:crs>
+                                    <lt7:st>18:50</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Trowbridge</lt7:locationName>
+                                    <lt7:crs>TRO</lt7:crs>
+                                    <lt7:st>18:56</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Westbury</lt7:locationName>
+                                    <lt7:crs>WSB</lt7:crs>
+                                    <lt7:st>19:04</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Warminster</lt7:locationName>
+                                    <lt7:crs>WMN</lt7:crs>
+                                    <lt7:st>19:12</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Salisbury</lt7:locationName>
+                                    <lt7:crs>SAL</lt7:crs>
+                                    <lt7:st>19:34</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Romsey</lt7:locationName>
+                                    <lt7:crs>ROM</lt7:crs>
+                                    <lt7:st>19:53</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Southampton Central</lt7:locationName>
+                                    <lt7:crs>SOU</lt7:crs>
+                                    <lt7:st>20:04</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Fareham</lt7:locationName>
+                                    <lt7:crs>FRM</lt7:crs>
+                                    <lt7:st>20:28</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Fratton</lt7:locationName>
+                                    <lt7:crs>FTN</lt7:crs>
+                                    <lt7:st>20:43</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Portsmouth &amp; Southsea</lt7:locationName>
+                                    <lt7:crs>PMS</lt7:crs>
+                                    <lt7:st>20:47</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Portsmouth Harbour</lt7:locationName>
+                                    <lt7:crs>PMH</lt7:crs>
+                                    <lt7:st>20:52</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:25</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>12</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2392780BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Avonmouth</lt4:locationName>
+                                <lt4:crs>AVN</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Weston-super-Mare</lt4:locationName>
+                                <lt4:crs>WSM</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bedminster</lt7:locationName>
+                                    <lt7:crs>BMT</lt7:crs>
+                                    <lt7:st>18:28</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Parson Street</lt7:locationName>
+                                    <lt7:crs>PSN</lt7:crs>
+                                    <lt7:st>18:31</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Nailsea &amp; Backwell</lt7:locationName>
+                                    <lt7:crs>NLS</lt7:crs>
+                                    <lt7:st>18:39</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Yatton</lt7:locationName>
+                                    <lt7:crs>YAT</lt7:crs>
+                                    <lt7:st>18:44</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Worle</lt7:locationName>
+                                    <lt7:crs>WOR</lt7:crs>
+                                    <lt7:st>18:50</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston Milton</lt7:locationName>
+                                    <lt7:crs>WNM</lt7:crs>
+                                    <lt7:st>18:55</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Weston-super-Mare</lt7:locationName>
+                                    <lt7:crs>WSM</lt7:crs>
+                                    <lt7:st>19:00</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:27</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of industrial action</lt4:cancelReason>
+                        <lt4:serviceID>2392493BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Taunton</lt4:locationName>
+                                <lt4:crs>TAU</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Cardiff Central</lt4:locationName>
+                                <lt4:crs>CDF</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Lawrence Hill</lt7:locationName>
+                                    <lt7:crs>LWH</lt7:crs>
+                                    <lt7:st>18:30</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Stapleton Road</lt7:locationName>
+                                    <lt7:crs>SRD</lt7:crs>
+                                    <lt7:st>18:34</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Filton Abbey Wood</lt7:locationName>
+                                    <lt7:crs>FIT</lt7:crs>
+                                    <lt7:st>18:39</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Patchway</lt7:locationName>
+                                    <lt7:crs>PWY</lt7:crs>
+                                    <lt7:st>18:45</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Severn Tunnel Junction</lt7:locationName>
+                                    <lt7:crs>STJ</lt7:crs>
+                                    <lt7:st>18:55</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newport (South Wales)</lt7:locationName>
+                                    <lt7:crs>NWP</lt7:crs>
+                                    <lt7:st>19:10</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Cardiff Central</lt7:locationName>
+                                    <lt7:crs>CDF</lt7:crs>
+                                    <lt7:st>19:27</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:30</lt4:std>
+                        <lt4:etd>On time</lt4:etd>
+                        <lt4:platform>13</lt4:platform>
+                        <lt4:operator>Great Western Railway</lt4:operator>
+                        <lt4:operatorCode>GW</lt4:operatorCode>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:serviceID>2389832BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Swindon</lt4:locationName>
+                                <lt4:crs>SWI</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Bath Spa</lt7:locationName>
+                                    <lt7:crs>BTH</lt7:crs>
+                                    <lt7:st>18:42</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Chippenham</lt7:locationName>
+                                    <lt7:crs>CPM</lt7:crs>
+                                    <lt7:st>18:55</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Swindon</lt7:locationName>
+                                    <lt7:crs>SWI</lt7:crs>
+                                    <lt7:st>19:09</lt7:st>
+                                    <lt7:et>On time</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Didcot Parkway</lt7:locationName>
+                                    <lt7:crs>DID</lt7:crs>
+                                    <lt7:st>19:26</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Reading</lt7:locationName>
+                                    <lt7:crs>RDG</lt7:crs>
+                                    <lt7:st>19:39</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>London Paddington</lt7:locationName>
+                                    <lt7:crs>PAD</lt7:crs>
+                                    <lt7:st>20:09</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                    <lt7:service>
+                        <lt4:std>18:45</lt4:std>
+                        <lt4:etd>Cancelled</lt4:etd>
+                        <lt4:operator>CrossCountry</lt4:operator>
+                        <lt4:operatorCode>XC</lt4:operatorCode>
+                        <lt4:isCancelled>true</lt4:isCancelled>
+                        <lt4:serviceType>train</lt4:serviceType>
+                        <lt4:cancelReason>This train has been cancelled because of a shortage of train drivers</lt4:cancelReason>
+                        <lt4:serviceID>2389409BRSTLTM_</lt4:serviceID>
+                        <lt5:origin>
+                            <lt4:location>
+                                <lt4:locationName>Edinburgh</lt4:locationName>
+                                <lt4:crs>EDB</lt4:crs>
+                            </lt4:location>
+                        </lt5:origin>
+                        <lt5:destination>
+                            <lt4:location>
+                                <lt4:locationName>Plymouth</lt4:locationName>
+                                <lt4:crs>PLY</lt4:crs>
+                            </lt4:location>
+                        </lt5:destination>
+                        <lt5:currentOrigins>
+                            <lt4:location>
+                                <lt4:locationName>Newcastle</lt4:locationName>
+                                <lt4:crs>NCL</lt4:crs>
+                            </lt4:location>
+                        </lt5:currentOrigins>
+                        <lt5:currentDestinations>
+                            <lt4:location>
+                                <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                <lt4:crs>BRI</lt4:crs>
+                            </lt4:location>
+                        </lt5:currentDestinations>
+                        <lt7:subsequentCallingPoints>
+                            <lt7:callingPointList>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Taunton</lt7:locationName>
+                                    <lt7:crs>TAU</lt7:crs>
+                                    <lt7:st>19:23</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Tiverton Parkway</lt7:locationName>
+                                    <lt7:crs>TVP</lt7:crs>
+                                    <lt7:st>19:35</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Exeter St Davids</lt7:locationName>
+                                    <lt7:crs>EXD</lt7:crs>
+                                    <lt7:st>19:50</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Newton Abbot</lt7:locationName>
+                                    <lt7:crs>NTA</lt7:crs>
+                                    <lt7:st>20:10</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Totnes</lt7:locationName>
+                                    <lt7:crs>TOT</lt7:crs>
+                                    <lt7:st>20:22</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                                <lt7:callingPoint>
+                                    <lt7:locationName>Plymouth</lt7:locationName>
+                                    <lt7:crs>PLY</lt7:crs>
+                                    <lt7:st>20:49</lt7:st>
+                                    <lt7:et>Cancelled</lt7:et>
+                                </lt7:callingPoint>
+                            </lt7:callingPointList>
+                        </lt7:subsequentCallingPoints>
+                    </lt7:service>
+                </lt7:trainServices>
+            </GetStationBoardResult>
+        </GetDepBoardWithDetailsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getFastestDeparture.xml
+++ b/test/fixtures/getFastestDeparture.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetFastestDeparturesResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <DeparturesBoard xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T18:26:12.7873358+00:00</lt4:generatedAt>
+                <lt4:locationName>Surbiton</lt4:locationName>
+                <lt4:crs>SUR</lt4:crs>
+                <lt4:nrccMessages>
+                    <lt:message>Disruption between Brookwood and Woking due to damage to a bridge. More details can be found in &lt;a href="https://www.nationalrail.co.uk/service-disruptions/brookwood-20231203/"&gt;Latest Travel News.&lt;/a&gt;</lt:message>
+                </lt4:nrccMessages>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:departures>
+                    <lt7:destination crs="WAT">
+                        <lt7:service>
+                            <lt4:sta>18:25</lt4:sta>
+                            <lt4:eta>18:27</lt4:eta>
+                            <lt4:std>18:26</lt4:std>
+                            <lt4:etd>18:28</lt4:etd>
+                            <lt4:platform>1</lt4:platform>
+                            <lt4:operator>South Western Railway</lt4:operator>
+                            <lt4:operatorCode>SW</lt4:operatorCode>
+                            <lt4:serviceType>train</lt4:serviceType>
+                            <lt4:serviceID>2401251SURBITN_</lt4:serviceID>
+                            <lt5:origin>
+                                <lt4:location>
+                                    <lt4:locationName>Woking</lt4:locationName>
+                                    <lt4:crs>WOK</lt4:crs>
+                                </lt4:location>
+                            </lt5:origin>
+                            <lt5:destination>
+                                <lt4:location>
+                                    <lt4:locationName>London Waterloo</lt4:locationName>
+                                    <lt4:crs>WAT</lt4:crs>
+                                </lt4:location>
+                            </lt5:destination>
+                        </lt7:service>
+                    </lt7:destination>
+                </lt7:departures>
+            </DeparturesBoard>
+        </GetFastestDeparturesResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getFastestDepartureWithDetails.xml
+++ b/test/fixtures/getFastestDepartureWithDetails.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetFastestDeparturesWithDetailsResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <DeparturesBoard xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T19:42:25.4503656+00:00</lt4:generatedAt>
+                <lt4:locationName>Bath Spa</lt4:locationName>
+                <lt4:crs>BTH</lt4:crs>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:departures>
+                    <lt7:destination crs="SWI">
+                        <lt7:service>
+                            <lt4:sta>19:43</lt4:sta>
+                            <lt4:eta>19:41</lt4:eta>
+                            <lt4:std>19:43</lt4:std>
+                            <lt4:etd>On time</lt4:etd>
+                            <lt4:platform>2</lt4:platform>
+                            <lt4:operator>Great Western Railway</lt4:operator>
+                            <lt4:operatorCode>GW</lt4:operatorCode>
+                            <lt4:serviceType>train</lt4:serviceType>
+                            <lt4:serviceID>2389837BATHSPA_</lt4:serviceID>
+                            <lt5:origin>
+                                <lt4:location>
+                                    <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                    <lt4:crs>BRI</lt4:crs>
+                                </lt4:location>
+                            </lt5:origin>
+                            <lt5:destination>
+                                <lt4:location>
+                                    <lt4:locationName>London Paddington</lt4:locationName>
+                                    <lt4:crs>PAD</lt4:crs>
+                                </lt4:location>
+                            </lt5:destination>
+                            <lt7:subsequentCallingPoints>
+                                <lt7:callingPointList>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Chippenham</lt7:locationName>
+                                        <lt7:crs>CPM</lt7:crs>
+                                        <lt7:st>19:56</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Swindon</lt7:locationName>
+                                        <lt7:crs>SWI</lt7:crs>
+                                        <lt7:st>20:09</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Didcot Parkway</lt7:locationName>
+                                        <lt7:crs>DID</lt7:crs>
+                                        <lt7:st>20:26</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Reading</lt7:locationName>
+                                        <lt7:crs>RDG</lt7:crs>
+                                        <lt7:st>20:39</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>London Paddington</lt7:locationName>
+                                        <lt7:crs>PAD</lt7:crs>
+                                        <lt7:st>21:08</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                </lt7:callingPointList>
+                            </lt7:subsequentCallingPoints>
+                        </lt7:service>
+                    </lt7:destination>
+                </lt7:departures>
+            </DeparturesBoard>
+        </GetFastestDeparturesWithDetailsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getNextDeparture.xml
+++ b/test/fixtures/getNextDeparture.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetNextDeparturesResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <DeparturesBoard xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T18:32:56.1797822+00:00</lt4:generatedAt>
+                <lt4:locationName>Bath Spa</lt4:locationName>
+                <lt4:crs>BTH</lt4:crs>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:departures>
+                    <lt7:destination crs="SWI">
+                        <lt7:service>
+                            <lt4:sta>18:42</lt4:sta>
+                            <lt4:eta>On time</lt4:eta>
+                            <lt4:std>18:44</lt4:std>
+                            <lt4:etd>On time</lt4:etd>
+                            <lt4:platform>2</lt4:platform>
+                            <lt4:operator>Great Western Railway</lt4:operator>
+                            <lt4:operatorCode>GW</lt4:operatorCode>
+                            <lt4:serviceType>train</lt4:serviceType>
+                            <lt4:serviceID>2389832BATHSPA_</lt4:serviceID>
+                            <lt5:origin>
+                                <lt4:location>
+                                    <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                    <lt4:crs>BRI</lt4:crs>
+                                </lt4:location>
+                            </lt5:origin>
+                            <lt5:destination>
+                                <lt4:location>
+                                    <lt4:locationName>Swindon</lt4:locationName>
+                                    <lt4:crs>SWI</lt4:crs>
+                                </lt4:location>
+                            </lt5:destination>
+                        </lt7:service>
+                    </lt7:destination>
+                </lt7:departures>
+            </DeparturesBoard>
+        </GetNextDeparturesResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getNextDepartureWithDetails.xml
+++ b/test/fixtures/getNextDepartureWithDetails.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetNextDeparturesWithDetailsResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <DeparturesBoard xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt4:generatedAt>2023-12-08T18:33:47.4667856+00:00</lt4:generatedAt>
+                <lt4:locationName>Bath Spa</lt4:locationName>
+                <lt4:crs>BTH</lt4:crs>
+                <lt4:platformAvailable>true</lt4:platformAvailable>
+                <lt7:departures>
+                    <lt7:destination crs="SWI">
+                        <lt7:service>
+                            <lt4:sta>18:42</lt4:sta>
+                            <lt4:eta>On time</lt4:eta>
+                            <lt4:std>18:44</lt4:std>
+                            <lt4:etd>On time</lt4:etd>
+                            <lt4:platform>2</lt4:platform>
+                            <lt4:operator>Great Western Railway</lt4:operator>
+                            <lt4:operatorCode>GW</lt4:operatorCode>
+                            <lt4:serviceType>train</lt4:serviceType>
+                            <lt4:serviceID>2389832BATHSPA_</lt4:serviceID>
+                            <lt5:origin>
+                                <lt4:location>
+                                    <lt4:locationName>Bristol Temple Meads</lt4:locationName>
+                                    <lt4:crs>BRI</lt4:crs>
+                                </lt4:location>
+                            </lt5:origin>
+                            <lt5:destination>
+                                <lt4:location>
+                                    <lt4:locationName>Swindon</lt4:locationName>
+                                    <lt4:crs>SWI</lt4:crs>
+                                </lt4:location>
+                            </lt5:destination>
+                            <lt7:subsequentCallingPoints>
+                                <lt7:callingPointList>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Chippenham</lt7:locationName>
+                                        <lt7:crs>CPM</lt7:crs>
+                                        <lt7:st>18:55</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Swindon</lt7:locationName>
+                                        <lt7:crs>SWI</lt7:crs>
+                                        <lt7:st>19:09</lt7:st>
+                                        <lt7:et>On time</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Didcot Parkway</lt7:locationName>
+                                        <lt7:crs>DID</lt7:crs>
+                                        <lt7:st>19:26</lt7:st>
+                                        <lt7:et>Cancelled</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>Reading</lt7:locationName>
+                                        <lt7:crs>RDG</lt7:crs>
+                                        <lt7:st>19:39</lt7:st>
+                                        <lt7:et>Cancelled</lt7:et>
+                                    </lt7:callingPoint>
+                                    <lt7:callingPoint>
+                                        <lt7:locationName>London Paddington</lt7:locationName>
+                                        <lt7:crs>PAD</lt7:crs>
+                                        <lt7:st>20:09</lt7:st>
+                                        <lt7:et>Cancelled</lt7:et>
+                                    </lt7:callingPoint>
+                                </lt7:callingPointList>
+                            </lt7:subsequentCallingPoints>
+                        </lt7:service>
+                    </lt7:destination>
+                </lt7:departures>
+            </DeparturesBoard>
+        </GetNextDeparturesWithDetailsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/fixtures/getServiceDetails.xml
+++ b/test/fixtures/getServiceDetails.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <GetServiceDetailsResponse xmlns="http://thalesgroup.com/RTTI/2017-10-01/ldb/">
+            <GetServiceDetailsResult xmlns:lt="http://thalesgroup.com/RTTI/2012-01-13/ldb/types"
+                xmlns:lt8="http://thalesgroup.com/RTTI/2021-11-01/ldb/types"
+                xmlns:lt6="http://thalesgroup.com/RTTI/2017-02-02/ldb/types"
+                xmlns:lt7="http://thalesgroup.com/RTTI/2017-10-01/ldb/types"
+                xmlns:lt4="http://thalesgroup.com/RTTI/2015-11-27/ldb/types"
+                xmlns:lt5="http://thalesgroup.com/RTTI/2016-02-16/ldb/types"
+                xmlns:lt2="http://thalesgroup.com/RTTI/2014-02-20/ldb/types"
+                xmlns:lt3="http://thalesgroup.com/RTTI/2015-05-14/ldb/types">
+                <lt7:generatedAt>2023-12-08T18:39:32.6132052+00:00</lt7:generatedAt>
+                <lt7:serviceType>train</lt7:serviceType>
+                <lt7:locationName>Bath Spa</lt7:locationName>
+                <lt7:crs>BTH</lt7:crs>
+                <lt7:operator>Great Western Railway</lt7:operator>
+                <lt7:operatorCode>GW</lt7:operatorCode>
+                <lt7:platform>2</lt7:platform>
+                <lt7:sta>18:42</lt7:sta>
+                <lt7:eta>On time</lt7:eta>
+                <lt7:std>18:44</lt7:std>
+                <lt7:etd>On time</lt7:etd>
+                <lt7:previousCallingPoints>
+                    <lt7:callingPointList>
+                        <lt7:callingPoint>
+                            <lt7:locationName>Bristol Temple Meads</lt7:locationName>
+                            <lt7:crs>BRI</lt7:crs>
+                            <lt7:st>18:30</lt7:st>
+                            <lt7:at>On time</lt7:at>
+                        </lt7:callingPoint>
+                    </lt7:callingPointList>
+                </lt7:previousCallingPoints>
+                <lt7:subsequentCallingPoints>
+                    <lt7:callingPointList>
+                        <lt7:callingPoint>
+                            <lt7:locationName>Chippenham</lt7:locationName>
+                            <lt7:crs>CPM</lt7:crs>
+                            <lt7:st>18:55</lt7:st>
+                            <lt7:et>On time</lt7:et>
+                        </lt7:callingPoint>
+                        <lt7:callingPoint>
+                            <lt7:locationName>Swindon</lt7:locationName>
+                            <lt7:crs>SWI</lt7:crs>
+                            <lt7:st>19:09</lt7:st>
+                            <lt7:et>On time</lt7:et>
+                        </lt7:callingPoint>
+                        <lt7:callingPoint>
+                            <lt7:locationName>Didcot Parkway</lt7:locationName>
+                            <lt7:crs>DID</lt7:crs>
+                            <lt7:st>19:26</lt7:st>
+                            <lt7:et>Cancelled</lt7:et>
+                        </lt7:callingPoint>
+                        <lt7:callingPoint>
+                            <lt7:locationName>Reading</lt7:locationName>
+                            <lt7:crs>RDG</lt7:crs>
+                            <lt7:st>19:39</lt7:st>
+                            <lt7:et>Cancelled</lt7:et>
+                        </lt7:callingPoint>
+                        <lt7:callingPoint>
+                            <lt7:locationName>London Paddington</lt7:locationName>
+                            <lt7:crs>PAD</lt7:crs>
+                            <lt7:st>20:09</lt7:st>
+                            <lt7:et>Cancelled</lt7:et>
+                        </lt7:callingPoint>
+                    </lt7:callingPointList>
+                </lt7:subsequentCallingPoints>
+            </GetServiceDetailsResult>
+        </GetServiceDetailsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/query.test.mjs
+++ b/test/query.test.mjs
@@ -1,0 +1,93 @@
+// @ts-check
+/* eslint-disable */
+import { describe, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import Parsers from '../parsers.js';
+function loadFixture(name) {
+  return fs.readFile(`./test/fixtures/${name}.xml`);
+}
+describe('Darwin', (it) => {
+  it('should return a list of departures', async () => {
+    const response = await loadFixture('getDepartureBoard');
+    const data = Parsers.parseDepartureBoardResponse(response);
+    expect(data.locationName).toBe('London Euston');
+    expect(data.crs).toBe('EUS');
+    expect(data.trainServices.length).toBeGreaterThan(0);
+  });
+
+  it('should return a list of arrivals', async () => {
+    const response = await loadFixture('getArrivalsBoard');
+    const data = Parsers.parseArrivalsBoardResponse(response);
+    expect(data.trainServices.length).toBeGreaterThan(0);
+  });
+
+  it('should return a list of arrivals and departures', async () => {
+    const response = await loadFixture('getArrivalsDepartureBoard');
+    const data = Parsers.parseArrivalsDepartureBoard(response);
+    expect(data.trainServices.length).toBeGreaterThan(0);
+  });
+
+  it('should return a list of arrivals and departures with details', async () => {
+    const response = await loadFixture('getArrivalsDepartureBoardWithDetails');
+    const data = Parsers.parseArrivalsDepartureBoardWithDetails(response);
+    expect(data.trainServices.length).toBeGreaterThan(0);
+    expect(data.trainServices[0].previousCallingPoints.length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('should return a list of arrivals with details', async () => {
+    const response = await loadFixture('getArrivalsBoardWithDetails');
+    const data = Parsers.parseArrivalsBoardWithDetails(response);
+    expect(data.trainServices.length).toBeGreaterThan(0);
+    expect(data.trainServices[0].previousCallingPoints.length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('should return a list of departures with details', async () => {
+    const response = await loadFixture('getDepartureBoardWithDetails');
+    const data = Parsers.parseDepartureBoardWithDetailsResponse(response);
+    expect(data.trainServices.length).toBeGreaterThan(0);
+    expect(
+      data.trainServices[0].subsequentCallingPoints.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('should return the fastest departure', async () => {
+    const response = await loadFixture('getFastestDeparture');
+    const data = Parsers.parseFastestDeparture(response);
+    expect(data.trainServices.length).toBe(1);
+  });
+
+  it('should return the fastest departure with details', async () => {
+    const response = await loadFixture('getFastestDepartureWithDetails');
+    const data = Parsers.parseFastestDepartureWithDetails(response);
+    expect(data.trainServices.length).toBe(1);
+    expect(
+      data.trainServices[0].subsequentCallingPoints.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('should return the next departure', async () => {
+    const response = await loadFixture('getNextDeparture');
+    const data = Parsers.parseNextDepartureResponse(response);
+    expect(data.trainServices.length).toBe(1);
+  });
+
+  it('should return the next departure with details', async () => {
+    const response = await loadFixture('getNextDepartureWithDetails');
+    const data = Parsers.parseNextDepartureWithDetailsResponse(response);
+    expect(data.trainServices.length).toBe(1);
+    expect(
+      data.trainServices[0].subsequentCallingPoints.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('should return service details', async () => {
+    const response = await loadFixture('getServiceDetails');
+    const data = Parsers.parseServiceDetails(response);
+    console.log(data);
+    expect(data.serviceDetails.previousCallingPoints.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
There are quite a few fields missing from responses that are present in the Darwin API. I started to add them, but there was quite a bit of repetitive code, so I refactored it to reuse more.

Once I had done that I wanted to nesure it was working properly, so I added tests. I don't want the tests to rely on the live API, so I saved example responses for each method as a fixture and use those to test against. I added a GitHub Action to run the tests.

This is quite a big refactor, so I'll understand if you don't want to merge it. I'm using my fork for now.